### PR TITLE
setcontracts - protocol not included by default

### DIFF
--- a/contracts/eosio.yield/eosio.yield.cpp
+++ b/contracts/eosio.yield/eosio.yield.cpp
@@ -347,7 +347,6 @@ void yield::setcontracts( const name protocol, const set<name> contracts )
     const name ram_payer = is_admin ? config.admin_contract : protocol;
     _protocols.modify( itr, ram_payer, [&]( auto& row ) {
         row.contracts = contracts;
-        row.contracts.insert(protocol); // always include EOS protocol account
         if ( contracts.size() > 1 ) row.status = "pending"_n; // must be re-approved if contracts changed
         row.updated_at = current_time_point();
         check( row.contracts != before_contracts, "yield::setcontracts: [contracts] was not modified");

--- a/contracts/eosio.yield/eosio.yield.spec.ts
+++ b/contracts/eosio.yield/eosio.yield.spec.ts
@@ -156,4 +156,10 @@ describe('eosio.yield', () => {
     const after = getProtocol("myprotocol");
     expect(after.status).toEqual("active");
   });
+
+  it("setcontracts - protocol not included by default", async () => {
+    await contracts.yield.eosio.actions.setcontracts([ "myprotocol", ["vault"] ]).send("admin.yield");
+    const protocol = getProtocol("myprotocol");
+    expect(protocol.contracts).toEqual(["vault"]);
+  });
 });

--- a/tests/init.ts
+++ b/tests/init.ts
@@ -22,7 +22,7 @@ export const contracts = {
 }
 
 // accounts
-export const accounts = blockchain.createAccounts('eosio', 'myprotocol', 'myoracle', 'myvault', "protocol1", "protocol2", "protocol3", "myaccount", "foobar");
+export const accounts = blockchain.createAccounts('eosio', 'myprotocol', 'myoracle', 'myvault', "protocol1", "protocol2", "protocol3", "myaccount", "vault", "foobar");
 
 // one-time setup
 beforeAll(async () => {


### PR DESCRIPTION
Allows `contracts` to not include `protocol` account by default.

`protocol` can be used as "admin" account and `contracts` can be vault & primary accounts.

Ref: https://github.com/eosnetworkfoundation/eosio.yield-contracts/issues/17