### PR TITLE
require config to be initialized before `regprotocol`

### DIFF
--- a/contracts/eosio.yield/eosio.yield.cpp
+++ b/contracts/eosio.yield/eosio.yield.cpp
@@ -414,7 +414,8 @@ void yield::remove_active_protocol( const name protocol )
 yield::config_row yield::get_config()
 {
     yield::config_table _config( get_self(), get_self().value );
-    return _config.get_or_default();
+    check( _config.exists(), "yield::get_config: [config] is not initialized");
+    return _config.get();
 }
 
 time_point_sec yield::get_current_period( const uint32_t period_interval )

--- a/contracts/eosio.yield/eosio.yield.spec.ts
+++ b/contracts/eosio.yield/eosio.yield.spec.ts
@@ -21,6 +21,12 @@ const getStatus = ( protocol: string ): string => {
 }
 
 describe('eosio.yield', () => {
+
+  it("error::regprotocol before init", async () => {
+    const action = contracts.yield.eosio.actions.regprotocol(["myprotocol", category, metadata_yield]).send('myprotocol@active');
+    await expectToThrow(action, "is not initialized");
+  });
+
   it("config::init", async () => {
     const EOS = {sym: "4,EOS", contract: "eosio.token"};
     await contracts.yield.eosio.actions.init([EOS, "oracle.yield", "admin.yield"]).send();


### PR DESCRIPTION
Fixes https://github.com/eosnetworkfoundation/eosio.yield-contracts/issues/18 & https://github.com/eosnetworkfoundation/eosio.yield-contracts/issues/16