### PR TITLE
Fix setcontracts

### DIFF
--- a/contracts/eosio.yield/eosio.yield.cpp
+++ b/contracts/eosio.yield/eosio.yield.cpp
@@ -142,8 +142,8 @@ void yield::set_status( const name protocol, const name status )
     auto & itr = _protocols.get(protocol.value, "yield::set_status: [protocol] does not exists");
     check( PROTOCOL_STATUS_TYPES.find( status ) != PROTOCOL_STATUS_TYPES.end(), "yield::set_status: [status] is invalid");
 
+    if ( itr.status == status ) return; // no status change
     _protocols.modify( itr, same_payer, [&]( auto& row ) {
-        check( row.status != status, "yield::set_status: [status] not modified");
         row.status = status;
     });
 

--- a/contracts/eosio.yield/eosio.yield.spec.ts
+++ b/contracts/eosio.yield/eosio.yield.spec.ts
@@ -145,7 +145,7 @@ describe('eosio.yield', () => {
     const protocol = getProtocol("myprotocol");
     expect(protocol.contracts).toEqual(eos_contracts);
 
-    const action = contracts.yield.eosio.actions.setcontracts([ "not.exists", eos_contracts ]).send("admin.yield");
+    const action = contracts.yield.eosio.actions.setcontracts([ "not.exists", eos_contracts ]).send();
     await expectToThrow(action, "does not exists");
   });
 
@@ -164,7 +164,7 @@ describe('eosio.yield', () => {
   });
 
   it("setcontracts - protocol not included by default", async () => {
-    await contracts.yield.eosio.actions.setcontracts([ "myprotocol", ["vault"] ]).send("admin.yield");
+    await contracts.yield.eosio.actions.setcontracts([ "myprotocol", ["vault"] ]).send();
     const protocol = getProtocol("myprotocol");
     expect(protocol.contracts).toEqual(["vault"]);
   });


### PR DESCRIPTION
- [x] `setcontracts` authorized by `eosio.yield`
- [x] remove `contracts.size() > 1` logic
- [x] trigger `set_status` inline logging

Ref: https://github.com/eosnetworkfoundation/eosio.yield-contracts/issues/25 https://github.com/eosnetworkfoundation/eosio.yield-contracts/issues/24

> override permission is required to allow certain protocols with nulled permission to be added to Yield+

CC: @YaroShkvorets