### PR TITLE
Yield+ EVM support

### DIFF
--- a/contracts/eosio.yield/README.md
+++ b/contracts/eosio.yield/README.md
@@ -243,7 +243,7 @@ $ cleos push action eosio.yield setmetakey '[myprotocol, website, "https://mypro
 
 > Unregister the {{protocol}} protocol.
 
-- **authority**: `protocol`
+- **authority**: `protocol` or `admin.yield`
 
 ### params
 
@@ -264,29 +264,14 @@ $ cleos push action eosio.yield unregister '[myprotocol]' -p myprotocol
 ### params
 
 - `{name} protocol` - protocol (will be included in EOS contracts)
-- `{set<name>} contracts` - additional EOS contracts
+- `{set<name>} contracts` - EOS smart contracts
+- `{set<string>} evm_contracts` - EOS EVM smart contracts
 
 ### Example
 
 ```bash
-$ cleos push action eosio.yield setcontracts '[myprotocol, [myvault]]' -p myprotocol -p myvault
-```
-
-## ACTION `setevm`
-
-> Sets EVM contracts for the {{protocol}} protocol.
-
-- **authority**: (`protocol` AND `evm`) OR `admin.yield`
-
-### params
-
-- `{name} protocol` - protocol (will be included in EOS contracts)
-- `{set<string>} evm` - additional EVM contracts
-
-### Example
-
-```bash
-$ cleos push action eosio.yield setevm '[myprotocol, ["0x2f9ec37d6ccfff1cab21733bdadede11c823ccb0"]]' -p myprotocol
+$ cleos push action eosio.yield setcontracts '[myprotocol, [myvault], []]' -p myprotocol
+$ cleos push action eosio.yield setcontracts '[myprotocol, [], ["0x2f9ec37d6ccfff1cab21733bdadede11c823ccb0"]]' -p myprotocol
 ```
 
 ## ACTION `approve`

--- a/contracts/eosio.yield/README.md
+++ b/contracts/eosio.yield/README.md
@@ -29,11 +29,14 @@ $ cleos push action eosio.yield setcontracts '[protocol, [a.protocol, b.protocol
 # claim rewards
 # > after 24 hours of being approved
 # > claimable every 10 minutes interval
-$ cleos push action eosio.yield claim '[myprotocol, null]' -p myprotocol
+$ cleos push action eosio.yield claim '[myprotocol, null, null]' -p myprotocol
 # //=> rewards sent to myprotocol
 
-$ cleos push action eosio.yield claim '[myprotocol, myreceiver]' -p myprotocol
+$ cleos push action eosio.yield claim '[myprotocol, myreceiver, null]' -p myprotocol
 # //=> rewards sent to myreceiver
+
+$ cleos push action eosio.yield claim '[myprotocol, null, "517144a9d542c6325CE77Ba2F94d2b05ACBaA087"]' -p myprotocol
+# // => rewards sent to 517144a9d542c6325CE77Ba2F94d2b05ACBaA087
 ```
 
 ### `ADMIN` (Operators)
@@ -333,15 +336,19 @@ $ cleos push action eosio.yield deny '[myprotocol]' -p admin.yield
 
 - `{name} protocol` - protocol
 - `{name} [receiver=""]` - (optional) receiver of rewards (default=protocol)
+- `{string} [evm_receiver=""]` - (optional) EVM receiver of rewards (default=protocol)
 
 ### Example
 
 ```bash
-$ cleos push action eosio.yield claim '[myprotocol, null]' -p myprotocol
-//=> rewards sent to myprotocol
+$ cleos push action eosio.yield claim '[myprotocol, null, null]' -p myprotocol
+# //=> rewards sent to myprotocol
 
-$ cleos push action eosio.yield claim '[myprotocol, myreceiver]' -p myprotocol
-//=> rewards sent to myreceiver
+$ cleos push action eosio.yield claim '[myprotocol, myreceiver, null]' -p myprotocol
+# //=> rewards sent to myreceiver
+
+$ cleos push action eosio.yield claim '[myprotocol, null, "517144a9d542c6325CE77Ba2F94d2b05ACBaA087"]' -p myprotocol
+# //=> rewards sent to 517144a9d542c6325CE77Ba2F94d2b05ACBaA087
 ```
 
 ## ACTION `claimlog`
@@ -355,6 +362,7 @@ $ cleos push action eosio.yield claim '[myprotocol, myreceiver]' -p myprotocol
 - `{name} protocol` - protocol
 - `{name} category` - protocol category
 - `{name} receiver` - receiver of rewards
+- `{string} evm_receiver` - EVM receiver of rewards
 - `{asset} claimed` - claimed rewards
 
 ### Example
@@ -364,6 +372,7 @@ $ cleos push action eosio.yield claim '[myprotocol, myreceiver]' -p myprotocol
     "protocol": "myprotocol",
     "category": "dexes",
     "receiver": "myreceiver",
+    "evm_receiver": "517144a9d542c6325CE77Ba2F94d2b05ACBaA087",
     "claimed":"1.5500 EOS"
 }
 ```

--- a/contracts/eosio.yield/eosio.yield.cpp
+++ b/contracts/eosio.yield/eosio.yield.cpp
@@ -206,7 +206,7 @@ void yield::deny( const name protocol )
 
 // @system
 [[eosio::action]]
-void yield::setrate( const int16_t annual_rate, const asset min_tvl_report, const asset max_tvl_report )
+void yield::setrate( const optional<int16_t> annual_rate, const optional<asset> min_tvl_report, const optional<asset> max_tvl_report )
 {
     require_auth( get_self() );
 
@@ -214,16 +214,15 @@ void yield::setrate( const int16_t annual_rate, const asset min_tvl_report, cons
     check( _config.exists(), "yield::setrate: contract must first call [init] action");
     auto config = get_config();
 
-    check( annual_rate <= MAX_ANNUAL_RATE, "yield::setrate: [annual_rate] exceeds maximum annual rate");
-    check( min_tvl_report <= max_tvl_report, "yield::setrate: [min_tvl_report] must be less than [max_tvl_report]");
+    if ( annual_rate ) config.annual_rate = *annual_rate;
+    if ( min_tvl_report ) config.min_tvl_report = *min_tvl_report;
+    if ( max_tvl_report ) config.max_tvl_report = *max_tvl_report;
 
-    // validate symbols
-    check( min_tvl_report.symbol == EOS, "yield::setrate: [min_tvl_report] invalid EOS symbol");
-    check( max_tvl_report.symbol == EOS, "yield::setrate: [min_tvl_report] invalid EOS symbol");
+    check( config.annual_rate <= MAX_ANNUAL_RATE, "yield::setrate: [annual_rate] exceeds maximum annual rate");
+    check( config.min_tvl_report <= config.max_tvl_report, "yield::setrate: [min_tvl_report] must be less than [max_tvl_report]");
+    check( config.min_tvl_report.symbol == EOS, "yield::setrate: [min_tvl_report] invalid EOS symbol");
+    check( config.max_tvl_report.symbol == EOS, "yield::setrate: [min_tvl_report] invalid EOS symbol");
 
-    config.annual_rate = annual_rate;
-    config.min_tvl_report = min_tvl_report;
-    config.max_tvl_report = max_tvl_report;
     _config.set(config, get_self());
 }
 

--- a/contracts/eosio.yield/eosio.yield.cpp
+++ b/contracts/eosio.yield/eosio.yield.cpp
@@ -345,6 +345,10 @@ void yield::setcontracts( const name protocol, const set<name> contracts, const 
     // Only support EOS or EVM contracts (not both)
     if ( evm_contracts.size() && contracts.size() ) check( false, "yield::setcontracts: cannot include both [evm_contracts] with [contracts]");
 
+    // maximum contracts per protocol (due to CPU limitations to compute TVL)
+    check( contracts.size() <= MAX_CONTRACTS, "yield::setcontracts: [contracts] cannot exceed 10 contracts per protocol");
+    check( evm_contracts.size() <= MAX_CONTRACTS, "yield::setcontracts: [evm_contracts] cannot exceed 10 contracts per protocol");
+
     // validate contracts
     for ( const name contract : contracts ) {
         check( is_account( contract ), "yield::setcontracts: [contract=" + contract.to_string() + "] account does not exists");

--- a/contracts/eosio.yield/eosio.yield.cpp
+++ b/contracts/eosio.yield/eosio.yield.cpp
@@ -2,6 +2,10 @@
 #include <eosio.token/eosio.token.hpp>
 #include <eosio.system/eosio.system.hpp>
 
+// EOS EVM
+#include <eosio.evm/eosio.evm.hpp>
+#include <eosio.evm/silkworm.hpp>
+
 // core
 #include <eosio.yield/eosio.yield.hpp>
 
@@ -64,9 +68,7 @@ void yield::setmetadata( const name protocol, const map<name, string> metadata )
     yield::protocols_table _protocols( get_self(), get_self().value );
     auto & itr = _protocols.get( protocol.value, "yield::setmetadata: [protocol] does not exists");
 
-    const auto config = get_config();
-    const name ram_payer = has_auth( config.admin_contract ) ? config.admin_contract : protocol;
-    _protocols.modify( itr, ram_payer, [&]( auto& row ) {
+    _protocols.modify( itr, get_ram_payer(protocol), [&]( auto& row ) {
         row.metadata = metadata;
         row.updated_at = current_time_point();
     });
@@ -83,15 +85,12 @@ void yield::setmetadata( const name protocol, const map<name, string> metadata )
 [[eosio::action]]
 void yield::setmetakey( const name protocol, const name key, const optional<string> value )
 {
-    const auto config = get_config();
-    const bool is_admin = has_auth( config.admin_contract );
-    if ( !is_admin ) require_auth( protocol );
+    require_auth_admin(protocol);
 
     yield::protocols_table _protocols( get_self(), get_self().value );
     auto & itr = _protocols.get( protocol.value, "yield::setmetakey: [protocol] does not exists");
 
-    const name ram_payer = is_admin ? config.admin_contract : protocol;
-    _protocols.modify( itr, ram_payer, [&]( auto& row ) {
+    _protocols.modify( itr, get_ram_payer(protocol), [&]( auto& row ) {
         if ( value ) row.metadata[key] = *value;
         else row.metadata.erase(key);
         row.updated_at = current_time_point();
@@ -109,10 +108,9 @@ void yield::setmetakey( const name protocol, const name key, const optional<stri
 [[eosio::action]]
 void yield::claim( const name protocol, const optional<name> receiver )
 {
-    require_auth( protocol );
+    require_auth_admin(protocol);
 
     yield::protocols_table _protocols( get_self(), get_self().value );
-    const auto config = get_config();
 
     if ( receiver ) check( is_account( *receiver ), "yield::claim: [receiver] does not exists");
 
@@ -259,8 +257,7 @@ void yield::init( const extended_symbol rewards, const name oracle_contract, con
 [[eosio::action]]
 void yield::unregister( const name protocol )
 {
-    const auto config = get_config();
-    if ( !has_auth( config.admin_contract )) require_auth( protocol );
+    require_auth_admin(protocol);
 
     yield::protocols_table _protocols( get_self(), get_self().value );
     auto & itr = _protocols.get(protocol.value, "yield::unregister: [protocol] does not exists");
@@ -334,30 +331,33 @@ void yield::report( const name protocol, const time_point_sec period, const uint
 
 // @protocol or @admin
 [[eosio::action]]
-void yield::setcontracts( const name protocol, const set<name> contracts )
+void yield::setcontracts( const name protocol, const set<name> contracts, const set<string> evm_contracts )
 {
-    const auto config = get_config();
-
     // override permission is required to allow certain protocols with nulled permission to be added to Yield+
-    const bool is_override = has_auth( get_self() );
-    if ( !is_override ) require_auth( protocol );
+    require_auth_admin(protocol);
 
     yield::protocols_table _protocols( get_self(), get_self().value );
     auto & itr = _protocols.get(protocol.value, "yield::setcontracts: [protocol] does not exists");
 
-    // require authority of all EOS contracts linked to protocol
+    // Only support EOS or EVM contracts (not both)
+    if ( evm_contracts.size() && contracts.size() ) check( false, "yield::setcontracts: cannot include both [evm_contracts] with [contracts]");
+
+    // validate contracts
     for ( const name contract : contracts ) {
         check( is_account( contract ), "yield::setcontracts: [contract=" + contract.to_string() + "] account does not exists");
-
-        // override permission does not need to validate contract permission
-        if ( !is_override ) require_auth( contract );
+    }
+    for ( const string evm_contract : evm_contracts ) {
+        check( evm_contract::is_account( *silkworm::from_hex(evm_contract) ), "yield::setcontracts: [evm_contract=" + evm_contract + "] account ID does not exists");
     }
 
     // modify contracts
-    const name ram_payer = is_override ? config.admin_contract : protocol;
-    _protocols.modify( itr, ram_payer, [&]( auto& row ) {
-        check( row.contracts != contracts, "yield::setcontracts: [contracts] was not modified");
+    _protocols.modify( itr, get_ram_payer(protocol), [&]( auto& row ) {
+        // prevent modification if no changes
+        if ( contracts.size() ) check( row.contracts != contracts, "yield::setcontracts: [contracts] was not modified");
+        if ( evm_contracts.size() ) check( row.evm_contracts != evm_contracts, "yield::setcontracts: [evm_contracts] was not modified");
+
         row.contracts = contracts;
+        row.evm_contracts = evm_contracts;
         row.updated_at = current_time_point();
     });
 
@@ -367,40 +367,7 @@ void yield::setcontracts( const name protocol, const set<name> contracts )
 
     // logging
     yield::contractslog_action contractslog( get_self(), { get_self(), "active"_n });
-    contractslog.send( protocol, itr.status, itr.contracts, itr.evm );
-}
-
-// @protocol or @admin
-[[eosio::action]]
-void yield::setevm( const name protocol, const set<string> evm )
-{
-    auto config = get_config();
-    const bool is_admin = has_auth( config.admin_contract );
-    if ( !is_admin ) require_auth( protocol );
-
-    yield::protocols_table _protocols( get_self(), get_self().value );
-    auto & itr = _protocols.get(protocol.value, "yield::setevm: [protocol] does not exists");
-
-    // require authority of all EVM contracts linked to protocol
-    for ( const string contract : evm ) {
-        check(false, "NOT IMPLEMENTED");
-    }
-
-    // modify contracts
-    const set<string> before_evm = itr.evm;
-    _protocols.modify( itr, protocol, [&]( auto& row ) {
-        row.evm = evm;
-        row.contracts.insert(protocol); // always include EOS protocol account
-        row.updated_at = current_time_point();
-        check( row.evm != before_evm, "yield::setevm: [evm] was not modified");
-    });
-
-    // must be re-approved if contracts changed
-    set_status(protocol, "pending"_n);
-
-    // logging
-    yield::contractslog_action contractslog( get_self(), { get_self(), "active"_n });
-    contractslog.send( protocol, itr.status, itr.contracts, itr.evm );
+    contractslog.send( protocol, itr.status, itr.contracts, itr.evm_contracts );
 }
 
 void yield::transfer( const name from, const name to, const extended_asset value, const string& memo )
@@ -440,7 +407,9 @@ time_point_sec yield::get_current_period( const uint32_t period_interval )
 
 bool yield::is_contract( const name contract )
 {
-    // NOT IMPLEMENTED NATIVE TO EOS - feature get code hash
+    // TO-DO: upgrade CDT to v4.0.0
+    // eosio::get_code_hash( contract );
+    // https://github.com/AntelopeIO/cdt/releases/tag/v4.0.0
     return true;
 }
 
@@ -453,4 +422,11 @@ void yield::require_auth_admin( const name account )
 {
     if ( has_auth( get_config().admin_contract ) ) return;
     require_auth( account );
+}
+
+name yield::get_ram_payer( const name account )
+{
+    const name admin = get_config().admin_contract;
+    if ( has_auth( admin ) ) return admin;
+    return account;
 }

--- a/contracts/eosio.yield/eosio.yield.hpp
+++ b/contracts/eosio.yield/eosio.yield.hpp
@@ -91,8 +91,8 @@ public:
      * - `{name} protocol` - primary protocol contract
      * - `{name} status="pending"` - status (`pending/active/denied`)
      * - `{name} category` - protocol category (ex: `dexes/lending/staking`)
-     * - `{set<name>} contracts` - additional supporting EOS contracts
-     * - `{set<string>} evm` - additional supporting EVM contracts
+     * - `{set<name>} contracts` - EOS contracts
+     * - `{set<string>} evm_contracts` - EOS EVM contracts
      * - `{asset} tvl` - reported TVL averaged value in EOS
      * - `{asset} usd` - reported TVL averaged value in USD
      * - `{extended_asset} balance` - balance available to be claimed
@@ -110,7 +110,7 @@ public:
      *     "status": "active",
      *     "category": "dexes",
      *     "contracts": ["myprotocol", "mytreasury"],
-     *     "evm": ["0x2f9ec37d6ccfff1cab21733bdadede11c823ccb0"],
+     *     "evm_contracts": ["0x2f9ec37d6ccfff1cab21733bdadede11c823ccb0"],
      *     "tvl": "200000.0000 EOS",
      *     "usd": "300000.0000 USD",
      *     "balance": {"quantity": "2.5000 EOS", "contract": "eosio.token"},
@@ -127,7 +127,7 @@ public:
         name                    status = "pending"_n;
         name                    category;
         set<name>               contracts;
-        set<string>             evm;
+        set<string>             evm_contracts;
         asset                   tvl;
         asset                   usd;
         extended_asset          balance;
@@ -280,37 +280,18 @@ public:
      * ### params
      *
      * - `{name} protocol` - protocol (will be included in EOS contracts)
-     * - `{set<name>} contracts` - additional EOS contracts
+     * - `{set<name>} contracts` - EOS smart contracts
+     * - `{set<string>} evm_contracts` - EOS EVM smart contracts
      *
      * ### Example
      *
      * ```bash
-     * $ cleos push action eosio.yield setcontracts '[myprotocol, [myvault]]' -p myprotocol -p myvault
+     * $ cleos push action eosio.yield setcontracts '[myprotocol, [myvault], []]' -p myprotocol
+     * $ cleos push action eosio.yield setcontracts '[myprotocol, [], ["0x2f9ec37d6ccfff1cab21733bdadede11c823ccb0"]]' -p myprotocol
      * ```
      */
     [[eosio::action]]
-    void setcontracts( const name protocol, const set<name> contracts );
-
-    /**
-     * ## ACTION `setevm`
-     *
-     * > Sets EVM contracts for the {{protocol}} protocol.
-     *
-     * - **authority**: (`protocol` AND `evm`) OR `admin.yield`
-     *
-     * ### params
-     *
-     * - `{name} protocol` - protocol (will be included in EOS contracts)
-     * - `{set<string>} evm` - additional EVM contracts
-     *
-     * ### Example
-     *
-     * ```bash
-     * $ cleos push action eosio.yield setevm '[myprotocol, ["0x2f9ec37d6ccfff1cab21733bdadede11c823ccb0"]]' -p myprotocol
-     * ```
-     */
-    [[eosio::action]]
-    void setevm( const name protocol, const set<string> evm );
+    void setcontracts( const name protocol, const set<name> contracts, const set<string> evm_contracts );
 
     /**
      * ## ACTION `approve`
@@ -661,6 +642,7 @@ private :
     void require_auth_admin();
     void require_auth_admin( const name account );
     bool is_contract( const name contract );
+    name get_ram_payer( const name account );
 
     // DEBUG (used to help testing)
     #ifdef DEBUG

--- a/contracts/eosio.yield/eosio.yield.hpp
+++ b/contracts/eosio.yield/eosio.yield.hpp
@@ -28,6 +28,7 @@ public:
     const set<name> PROTOCOL_STATUS_TYPES = set<name>{"pending"_n, "active"_n, "denied"_n};
     const uint16_t MAX_ANNUAL_RATE = 1000; // maximum rate of 10%
     const uint32_t YEAR = 31536000; // 365 days in seconds
+    const uint16_t MAX_CONTRACTS = 10; // maximum 10 contracts per protocol (due to CPU limitations to compute TVL)
 
     // ERROR MESSAGES
     const string ERROR_CONFIG_NOT_EXISTS = "yield::error: contract is under maintenance";

--- a/contracts/eosio.yield/eosio.yield.hpp
+++ b/contracts/eosio.yield/eosio.yield.hpp
@@ -365,19 +365,23 @@ public:
      *
      * - `{name} protocol` - protocol
      * - `{name} [receiver=""]` - (optional) receiver of rewards (default=protocol)
+     * - `{string} [evm_receiver=""]` - (optional) EVM receiver of rewards (default=protocol)
      *
      * ### Example
      *
      * ```bash
-     * $ cleos push action eosio.yield claim '[myprotocol, null]' -p myprotocol
+     * $ cleos push action eosio.yield claim '[myprotocol, null, null]' -p myprotocol
      * //=> rewards sent to myprotocol
      *
-     * $ cleos push action eosio.yield claim '[myprotocol, myreceiver]' -p myprotocol
+     * $ cleos push action eosio.yield claim '[myprotocol, myreceiver, null]' -p myprotocol
      * //=> rewards sent to myreceiver
+     *
+     * $ cleos push action eosio.yield claim '[myprotocol, null, "517144a9d542c6325CE77Ba2F94d2b05ACBaA087"]' -p myprotocol
+     * //=> rewards sent to 517144a9d542c6325CE77Ba2F94d2b05ACBaA087
      * ```
      */
     [[eosio::action]]
-    void claim( const name protocol, const optional<name> receiver );
+    void claim( const name protocol, const optional<name> receiver, const optional<string> evm_receiver );
 
     /**
      * ## ACTION `report`
@@ -415,6 +419,7 @@ public:
      * - `{name} protocol` - protocol
      * - `{name} category` - protocol category
      * - `{name} [receiver=""]` - (optional) receiver of rewards
+     * - `{string} [evm_receiver=""]` - (optional) EVM receiver of rewards
      * - `{asset} claimed` - claimed rewards
      * - `{asset} balance` - balance available to be claimed
      *
@@ -425,13 +430,14 @@ public:
      *     "protocol": "myprotocol",
      *     "category": "dexes",
      *     "receiver": "myreceiver",
+     *     "evm_receiver": "517144a9d542c6325CE77Ba2F94d2b05ACBaA087",
      *     "claimed": "1.5500 EOS",
      *     "balance": 0.0000 EOS"
      * }
      * ```
      */
     [[eosio::action]]
-    void claimlog( const name protocol, const name category, const name receiver, const asset claimed, const asset balance );
+    void claimlog( const name protocol, const name category, const name receiver, const string evm_receiver, const asset claimed, const asset balance );
 
     /**
      * ## ACTION `rewardslog`

--- a/contracts/eosio.yield/eosio.yield.hpp
+++ b/contracts/eosio.yield/eosio.yield.hpp
@@ -172,18 +172,19 @@ public:
      *
      * ### params
      *
-     * - `{uint16_t} annual_rate` - annual rate (pips 1/100 of 1%)
-     * - `{asset} min_tvl_report` - minimum TVL report
-     * - `{asset} max_tvl_report` - maximum TVL report
+     * - `{uint16_t} [annual_rate]` - (optional) annual rate (pips 1/100 of 1%)
+     * - `{asset} [min_tvl_report]` - (optional) minimum TVL report
+     * - `{asset} [max_tvl_report]` - (optional) maximum TVL report
      *
      * ### Example
      *
      * ```bash
      * $ cleos push action eosio.yield setrate '[500, "200000.0000 EOS", "6000000.0000 EOS"]' -p eosio.yield
+     * $ cleos push action eosio.yield setrate '[500, null, null]' -p eosio.yield
      * ```
      */
     [[eosio::action]]
-    void setrate( const int16_t annual_rate, const asset min_tvl_report, const asset max_tvl_report );
+    void setrate( const optional<int16_t> annual_rate, const optional<asset> min_tvl_report, const optional<asset> max_tvl_report );
 
     /**
      * ## ACTION `regprotocol`

--- a/contracts/eosio.yield/eosio.yield.hpp
+++ b/contracts/eosio.yield/eosio.yield.hpp
@@ -255,7 +255,7 @@ public:
      *
      * > Unregister the {{protocol}} protocol.
      *
-     * - **authority**: `protocol`
+     * - **authority**: `protocol` or `admin.yield`
      *
      * ### params
      *

--- a/contracts/eosio.yield/eosio.yield.spec.ts
+++ b/contracts/eosio.yield/eosio.yield.spec.ts
@@ -146,7 +146,7 @@ describe('eosio.yield', () => {
     expect(protocol.contracts).toEqual(eos_contracts);
 
     const action = contracts.yield.eosio.actions.setcontracts([ "not.exists", eos_contracts, [] ]).send();
-    await expectToThrow(action, "does not exists");
+    await expectToThrow(action, "missing required authority not.exists");
   });
 
   it("admin::approve", async () => {

--- a/contracts/eosio.yield/eosio.yield.spec.ts
+++ b/contracts/eosio.yield/eosio.yield.spec.ts
@@ -149,11 +149,6 @@ describe('eosio.yield', () => {
     await expectToThrow(action, "does not exists");
   });
 
-  it("setevm", async () => {
-    const action = contracts.yield.eosio.actions.setevm([ "myprotocol", evm_contracts ]).send("myprotocol@active");
-    await expectToThrow(action, "NOT IMPLEMENTED");
-  });
-
   it("admin::approve", async () => {
     const before = getProtocol("myprotocol");
     expect(before.status).toEqual("pending");

--- a/contracts/eosio.yield/eosio.yield.spec.ts
+++ b/contracts/eosio.yield/eosio.yield.spec.ts
@@ -141,11 +141,11 @@ describe('eosio.yield', () => {
 
   it("setcontracts", async () => {
     const auth = eos_contracts.map(contract => { return { actor: contract, permission: "active"} });
-    await contracts.yield.eosio.actions.setcontracts([ "myprotocol", eos_contracts ]).send(auth);
+    await contracts.yield.eosio.actions.setcontracts([ "myprotocol", eos_contracts, [] ]).send(auth);
     const protocol = getProtocol("myprotocol");
     expect(protocol.contracts).toEqual(eos_contracts);
 
-    const action = contracts.yield.eosio.actions.setcontracts([ "not.exists", eos_contracts ]).send();
+    const action = contracts.yield.eosio.actions.setcontracts([ "not.exists", eos_contracts, [] ]).send();
     await expectToThrow(action, "does not exists");
   });
 
@@ -164,7 +164,7 @@ describe('eosio.yield', () => {
   });
 
   it("setcontracts - protocol not included by default", async () => {
-    await contracts.yield.eosio.actions.setcontracts([ "myprotocol", ["vault"] ]).send();
+    await contracts.yield.eosio.actions.setcontracts([ "myprotocol", ["vault"], [] ]).send();
     const protocol = getProtocol("myprotocol");
     expect(protocol.contracts).toEqual(["vault"]);
   });

--- a/contracts/eosio.yield/eosio.yield.spec.ts
+++ b/contracts/eosio.yield/eosio.yield.spec.ts
@@ -159,7 +159,7 @@ describe('eosio.yield', () => {
   });
 
   it("setcontracts - protocol not included by default", async () => {
-    await contracts.yield.eosio.actions.setcontracts([ "myprotocol", ["vault"], [] ]).send();
+    await contracts.yield.eosio.actions.setcontracts([ "myprotocol", ["vault"], [] ]).send("myprotocol@active");
     const protocol = getProtocol("myprotocol");
     expect(protocol.contracts).toEqual(["vault"]);
   });

--- a/contracts/eosio.yield/scripts/build.sh
+++ b/contracts/eosio.yield/scripts/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # compile
-blanc++ eosio.yield.cpp -I ../ -I ../../external
-# cdt-cpp eosio.yield.cpp -I ../ -I ../../external
+# blanc++ eosio.yield.cpp -I ../ -I ../../external
+cdt-cpp eosio.yield.cpp -I ../ -I ../../external
 
 # # external contracts
 # if [ ! -f "./include/eosio.token/eosio.token.wasm" ]; then

--- a/contracts/eosio.yield/scripts/build.sh
+++ b/contracts/eosio.yield/scripts/build.sh
@@ -13,6 +13,6 @@ cdt-cpp eosio.yield.cpp -I ../ -I ../../external
 #     eosio-cpp ./include/eosio.system/eosio.system.cpp -I include -o include/eosio.system/eosio.system.wasm
 # fi
 
-# unlock wallet & deploy
-cleos wallet unlock --password $(cat ~/eosio-wallet/.pass)
-cleos set contract eosio.yield . eosio.yield.wasm eosio.yield.abi
+# # unlock wallet & deploy
+# cleos wallet unlock --password $(cat ~/eosio-wallet/.pass)
+# cleos set contract eosio.yield . eosio.yield.wasm eosio.yield.abi

--- a/contracts/eosio.yield/scripts/build.sh
+++ b/contracts/eosio.yield/scripts/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # compile
-blanc++ eosio.yield.cpp -I ../ -I ../../external
+cdt-cpp eosio.yield.cpp -I ../ -I ../../external
+# blanc++ eosio.yield.cpp -I ../ -I ../../external
 
 # # external contracts
 # if [ ! -f "./include/eosio.token/eosio.token.wasm" ]; then

--- a/contracts/eosio.yield/scripts/build.sh
+++ b/contracts/eosio.yield/scripts/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # compile
-cdt-cpp eosio.yield.cpp -I ../ -I ../../external
-# blanc++ eosio.yield.cpp -I ../ -I ../../external
+blanc++ eosio.yield.cpp -I ../ -I ../../external
+# cdt-cpp eosio.yield.cpp -I ../ -I ../../external
 
 # # external contracts
 # if [ ! -f "./include/eosio.token/eosio.token.wasm" ]; then

--- a/contracts/eosio.yield/src/logs.cpp
+++ b/contracts/eosio.yield/src/logs.cpp
@@ -20,7 +20,7 @@ void yield::rewardslog( const name protocol, const name category, const time_poi
 
 // @eosio.code
 [[eosio::action]]
-void yield::claimlog( const name protocol, const name category, const name receiver, const asset claimed, const asset balance )
+void yield::claimlog( const name protocol, const name category, const name receiver, const string evm_receiver, const asset claimed, const asset balance )
 {
     require_auth( get_self() );
     notify_admin();

--- a/contracts/oracle.yield/README.md
+++ b/contracts/oracle.yield/README.md
@@ -167,8 +167,8 @@ cleos push action oracle.yield deltoken '["EOS"]' -p oracle.yield
 - `{time_point_sec} period` - (primary key) period at time
 - `{name} protocol` - protocol contract
 - `{name} category` - protocol category
-- `{set<name>} contracts.eos` - additional supporting EOS contracts
-- `{set<string>} contracts.evm` - additional supporting EVM contracts
+- `{set<name>} contracts` - EOS contracts
+- `{set<string>} evm_contracts` - EOS EVM contracts
 - `{vector<asset>} balances` - asset balances
 - `{vector<asset>} prices` - currency prices
 - `{asset} tvl` - reported TVL averaged value in EOS
@@ -181,7 +181,7 @@ cleos push action oracle.yield deltoken '["EOS"]' -p oracle.yield
     "period": "2022-05-13T00:00:00",
     "protocol": "myprotocol",
     "contracts": ["myprotocol", "mytreasury"],
-    "evm": ["0x2f9ec37d6ccfff1cab21733bdadede11c823ccb0"],
+    "evm_contracts": ["0x2f9ec37d6ccfff1cab21733bdadede11c823ccb0"],
     "balances": ["1000.0000 EOS", "1500.0000 USDT"],
     "prices": ["1.5000 USD", "1.0000 USD"],
     "tvl": "200000.0000 EOS",

--- a/contracts/oracle.yield/README.md
+++ b/contracts/oracle.yield/README.md
@@ -52,6 +52,7 @@ cleos push action oracle.yield deltoken '["EOS"]' -p oracle.yield
 - [TABLE `periods`](#table-periods)
 - [TABLE `oracles`](#table-oracles)
 - [ACTION `addevmtoken`](#action-addevmtoken)
+- [ACTION `delevmtoken`](#action-delevmtoken)
 - [ACTION `init`](#action-init)
 - [ACTION `addtoken`](#action-addtoken)
 - [ACTION `deltoken`](#action-deltoken)
@@ -212,6 +213,41 @@ cleos push action oracle.yield deltoken '["EOS"]' -p oracle.yield
     "updated_at": "2022-05-13T00:00:00",
     "claimed_at": "1970-01-01T00:00:00"
 }
+```
+
+## ACTION `addevmtoken`
+
+- **authority**: `get_self()`
+
+> Add {{sym}} token using {{address}} EOS EVM address.
+
+### params
+
+- `{bytes} address` - token EOS EVM address
+- `{uint8_t} decimals` - token decimals
+- `{symbol_code} symcode` - token symbol code
+
+### example
+
+```bash
+$ cleos push action oracle.yield addevmtoken '["0xfa9343c3897324496a05fc75abed6bac29f8a40f", 6, "USDT"]' -p oracle.yield
+$ cleos push action oracle.yield addevmtoken '["0xc00592aA41D32D137dC480d9f6d0Df19b860104F", 18, "EOS"]' -p oracle.yield
+```
+
+## ACTION `delevmtoken`
+
+- **authority**: `get_self()`
+
+> Delete {{address}} EOS EVM token as supported asset
+
+### params
+
+- `{bytes} address` - EOS EVM token address
+
+### example
+
+```bash
+$ cleos push action oracle.yield deltoken '["fa9343c3897324496a05fc75abed6bac29f8a40f"]' -p oracle.yield
 ```
 
 ## ACTION `init`

--- a/contracts/oracle.yield/README.md
+++ b/contracts/oracle.yield/README.md
@@ -74,7 +74,7 @@ cleos push action oracle.yield deltoken '["EOS"]' -p oracle.yield
 ### params
 
 - `{uint64_t} token_id` - (primary key) EOS EVM token account ID
-- `{string} address` - EOS EVM token address
+- `{bytes} address` - EOS EVM token address
 - `{uint8_t} decimals` - EOS EVM token decimals
 - `{symbol} sym` - token symbol
 
@@ -104,7 +104,7 @@ cleos push action oracle.yield deltoken '["EOS"]' -p oracle.yield
 ### params
 
 - `{uint64_t} address_id` - (primary key) EOS EVM address account ID
-- `{string} address` - EOS EVM address
+- `{bytes} address` - EOS EVM address
 - `{asset} balance` - current token balance
 
 ### example

--- a/contracts/oracle.yield/README.md
+++ b/contracts/oracle.yield/README.md
@@ -44,13 +44,14 @@ $ cleos push action oracle.yield addtoken '["4,EOS", "eosio.token", 1, "eosusd"]
 # delete token
 cleos push action oracle.yield deltoken '["EOS"]' -p oracle.yield
 ```
-
 ## Table of Content
 
+- [TABLE `evm.tokens`](#table-evm.tokens)
 - [TABLE `config`](#table-config)
 - [TABLE `tokens`](#table-tokens)
 - [TABLE `periods`](#table-periods)
 - [TABLE `oracles`](#table-oracles)
+- [ACTION `addevmtoken`](#action-addevmtoken)
 - [ACTION `init`](#action-init)
 - [ACTION `addtoken`](#action-addtoken)
 - [ACTION `deltoken`](#action-deltoken)
@@ -67,6 +68,34 @@ cleos push action oracle.yield deltoken '["EOS"]' -p oracle.yield
 - [ACTION `claim`](#action-claim)
 - [ACTION `claimlog`](#action-claimlog)
 - [ACTION `rewardslog`](#action-rewardslog)
+
+## TABLE `evm.tokens`
+
+### params
+
+- `{uint64_t} account_id` - (primary key) EOS EVM account ID
+- `{symbol} sym` - token symbol
+- `{string} address` - EOS EVM token address
+- `{uint8_t} decimals` - EOS EVM token decimals
+
+### example
+
+```json
+[
+    {
+        "token_id": 2,
+        "sym": "4,EOS",
+        "address": "0xc00592aA41D32D137dC480d9f6d0Df19b860104F",
+        "decimals": "18"
+    }
+    {
+        "token_id": 1,
+        "sym": "4,USDT",
+        "address": "0xfa9343c3897324496a05fc75abed6bac29f8a40f",
+        "decimals": "6"
+    },
+]
+```
 
 ## TABLE `config`
 

--- a/contracts/oracle.yield/README.md
+++ b/contracts/oracle.yield/README.md
@@ -73,10 +73,10 @@ cleos push action oracle.yield deltoken '["EOS"]' -p oracle.yield
 
 ### params
 
-- `{uint64_t} account_id` - (primary key) EOS EVM account ID
-- `{symbol} sym` - token symbol
+- `{uint64_t} token_id` - (primary key) EOS EVM token account ID
 - `{string} address` - EOS EVM token address
 - `{uint8_t} decimals` - EOS EVM token decimals
+- `{symbol} sym` - token symbol
 
 ### example
 
@@ -84,17 +84,37 @@ cleos push action oracle.yield deltoken '["EOS"]' -p oracle.yield
 [
     {
         "token_id": 2,
-        "sym": "4,EOS",
-        "address": "0xc00592aA41D32D137dC480d9f6d0Df19b860104F",
-        "decimals": "18"
+        "address": "c00592aA41D32D137dC480d9f6d0Df19b860104F",
+        "decimals": "18",
+        "sym": "4,EOS"
     }
     {
-        "token_id": 1,
+        "token_id": 201,
         "sym": "4,USDT",
-        "address": "0xfa9343c3897324496a05fc75abed6bac29f8a40f",
+        "address": "fa9343c3897324496a05fc75abed6bac29f8a40f",
         "decimals": "6"
     },
 ]
+```
+
+## TABLE `evm.balances`
+
+**Scope**: `<uint64_t> token_id`
+
+### params
+
+- `{uint64_t} address_id` - (primary key) EOS EVM address account ID
+- `{string} address` - EOS EVM address
+- `{asset} balance` - current token balance
+
+### example
+
+```json
+{
+    "address_id": 663,
+    "address": "671A5e209A5496256ee21386EC3EaB9054d658A2",
+    "balance": "173151.7110 USDT"
+}
 ```
 
 ## TABLE `config`

--- a/contracts/oracle.yield/README.md
+++ b/contracts/oracle.yield/README.md
@@ -230,8 +230,8 @@ cleos push action oracle.yield deltoken '["EOS"]' -p oracle.yield
 ### example
 
 ```bash
-$ cleos push action oracle.yield addevmtoken '["0xfa9343c3897324496a05fc75abed6bac29f8a40f", 6, "USDT"]' -p oracle.yield
-$ cleos push action oracle.yield addevmtoken '["0xc00592aA41D32D137dC480d9f6d0Df19b860104F", 18, "EOS"]' -p oracle.yield
+$ cleos push action oracle.yield addevmtoken '["fa9343c3897324496a05fc75abed6bac29f8a40f", 6, "USDT"]' -p oracle.yield
+$ cleos push action oracle.yield addevmtoken '["c00592aA41D32D137dC480d9f6d0Df19b860104F", 18, "EOS"]' -p oracle.yield
 ```
 
 ## ACTION `delevmtoken`

--- a/contracts/oracle.yield/README.md
+++ b/contracts/oracle.yield/README.md
@@ -47,6 +47,7 @@ cleos push action oracle.yield deltoken '["EOS"]' -p oracle.yield
 ## Table of Content
 
 - [TABLE `evm.tokens`](#table-evm.tokens)
+- [TABLE `evm.balances`](#table-evm.balances)
 - [TABLE `config`](#table-config)
 - [TABLE `tokens`](#table-tokens)
 - [TABLE `periods`](#table-periods)

--- a/contracts/oracle.yield/README.md
+++ b/contracts/oracle.yield/README.md
@@ -225,14 +225,14 @@ cleos push action oracle.yield deltoken '["EOS"]' -p oracle.yield
 ### params
 
 - `{bytes} address` - token EOS EVM address
-- `{uint8_t} decimals` - token decimals
-- `{symbol_code} symcode` - token symbol code
+- `{uint8_t} decimals` - token EOS EVM decimals
+- `{symbol} symcode` - token symbol
 
 ### example
 
 ```bash
-$ cleos push action oracle.yield addevmtoken '["fa9343c3897324496a05fc75abed6bac29f8a40f", 6, "USDT"]' -p oracle.yield
-$ cleos push action oracle.yield addevmtoken '["c00592aA41D32D137dC480d9f6d0Df19b860104F", 18, "EOS"]' -p oracle.yield
+$ cleos push action oracle.yield addevmtoken '["fa9343c3897324496a05fc75abed6bac29f8a40f", 6, "4,USDT"]' -p oracle.yield
+$ cleos push action oracle.yield addevmtoken '["c00592aA41D32D137dC480d9f6d0Df19b860104F", 18, "4,EOS"]' -p oracle.yield
 ```
 
 ## ACTION `delevmtoken`

--- a/contracts/oracle.yield/oracle.yield.contracts.md
+++ b/contracts/oracle.yield/oracle.yield.contracts.md
@@ -35,6 +35,16 @@ summary: 'Add {{sym}} token using {{address}} EOS EVM address.'
 icon: https://gateway.pinata.cloud/ipfs/QmSPLWbpUttHQqd4gPnPKBGE6XWy6PricPgfns9LXoUjdk#88016c23a1ed3af668f50353523ba29d086a8d3a460340b6e53add24588e5c5c
 ---
 
+
+<h1 class="contract">delevmtoken</h1>
+
+---
+spec_version: "0.2.0"
+title: Delete EVM Token
+summary: 'Delete {{address}} EOS EVM token.'
+icon: https://gateway.pinata.cloud/ipfs/QmSPLWbpUttHQqd4gPnPKBGE6XWy6PricPgfns9LXoUjdk#88016c23a1ed3af668f50353523ba29d086a8d3a460340b6e53add24588e5c5c
+---
+
 <h1 class="contract">addtoken</h1>
 
 ---

--- a/contracts/oracle.yield/oracle.yield.contracts.md
+++ b/contracts/oracle.yield/oracle.yield.contracts.md
@@ -1,3 +1,31 @@
+<h1 class="contract">balanceof</h1>
+
+---
+spec_version: "0.2.0"
+title: balanceof
+---
+
+<h1 class="contract">callback</h1>
+
+---
+spec_version: "0.2.0"
+title: callback
+---
+
+<h1 class="contract">balance</h1>
+
+---
+spec_version: "0.2.0"
+title: balance
+---
+
+<h1 class="contract">test</h1>
+
+---
+spec_version: "0.2.0"
+title: test
+---
+
 <h1 class="contract">addevmtoken</h1>
 
 ---

--- a/contracts/oracle.yield/oracle.yield.contracts.md
+++ b/contracts/oracle.yield/oracle.yield.contracts.md
@@ -19,11 +19,11 @@ spec_version: "0.2.0"
 title: balance
 ---
 
-<h1 class="contract">test</h1>
+<h1 class="contract">setbalance</h1>
 
 ---
 spec_version: "0.2.0"
-title: test
+title: setbalance
 ---
 
 <h1 class="contract">addevmtoken</h1>

--- a/contracts/oracle.yield/oracle.yield.contracts.md
+++ b/contracts/oracle.yield/oracle.yield.contracts.md
@@ -1,3 +1,12 @@
+<h1 class="contract">addevmtoken</h1>
+
+---
+spec_version: "0.2.0"
+title: Add EVM Token
+summary: 'Add {{sym}} token using {{address}} EOS EVM address.'
+icon: https://gateway.pinata.cloud/ipfs/QmSPLWbpUttHQqd4gPnPKBGE6XWy6PricPgfns9LXoUjdk#88016c23a1ed3af668f50353523ba29d086a8d3a460340b6e53add24588e5c5c
+---
+
 <h1 class="contract">addtoken</h1>
 
 ---

--- a/contracts/oracle.yield/oracle.yield.cpp
+++ b/contracts/oracle.yield/oracle.yield.cpp
@@ -9,6 +9,9 @@
 // core
 #include <oracle.yield/oracle.yield.hpp>
 
+// EOS EVM
+#include <eosio.evm/eosio.evm.hpp>
+
 // logging (used for backend syncing)
 #include "src/logs.cpp"
 

--- a/contracts/oracle.yield/oracle.yield.cpp
+++ b/contracts/oracle.yield/oracle.yield.cpp
@@ -6,17 +6,20 @@
 #include <oracle.defi/oracle.defi.hpp>
 #include <delphioracle/delphioracle.hpp>
 
-// core
-#include <oracle.yield/oracle.yield.hpp>
-
 // EOS EVM
 #include <eosio.evm/eosio.evm.hpp>
+#include <eosio.evm/silkworm.hpp>
+#include <eosio.evm/intx.hpp>
+
+// core
+#include <oracle.yield/oracle.yield.hpp>
 
 // logging (used for backend syncing)
 #include "src/logs.cpp"
 
 // EOS EVM support
 #include "src/evm.cpp"
+#include "src/evm.callback.cpp"
 
 // DEBUG (used to help testing)
 #ifdef DEBUG

--- a/contracts/oracle.yield/oracle.yield.cpp
+++ b/contracts/oracle.yield/oracle.yield.cpp
@@ -12,6 +12,9 @@
 // logging (used for backend syncing)
 #include "src/logs.cpp"
 
+// EOS EVM support
+#include "src/evm.cpp"
+
 // DEBUG (used to help testing)
 #ifdef DEBUG
 #include "src/debug.cpp"

--- a/contracts/oracle.yield/oracle.yield.hpp
+++ b/contracts/oracle.yield/oracle.yield.hpp
@@ -750,6 +750,16 @@ public:
     [[eosio::action]]
     void rewardslog( const name oracle, const asset rewards, const asset balance );
 
+    [[eosio::action]]
+    void callback( const int32_t status, bytes data, const std::optional<bytes> context );
+
+    [[eosio::action]]
+    void balanceof( const string contract, const string address );
+
+    [[eosio::action]]
+    void test( const string contract, const string address, const int64_t amount );
+    using test_action = eosio::action_wrapper<"test"_n, &oracle::test>;
+
     [[eosio::on_notify("*::transfer")]]
     void on_transfer( const name from, const name to, const asset quantity, const std::string memo );
 
@@ -811,6 +821,9 @@ private:
     int64_t normalize_price( const int64_t price, const uint8_t precision );
     int64_t get_delphi_price( const name delphi_oracle_id );
     int64_t get_defibox_price( const uint64_t defibox_oracle_id );
+
+    // EVM
+    int64_t bytes_to_int64( const bytes data, const uint8_t decimals );
 
     // DEBUG (used to help testing)
     #ifdef DEBUG

--- a/contracts/oracle.yield/oracle.yield.hpp
+++ b/contracts/oracle.yield/oracle.yield.hpp
@@ -98,6 +98,45 @@ public:
     typedef eosio::multi_index< "tokens"_n, tokens_row> tokens_table;
 
     /**
+     * ## TABLE `evm.tokens`
+     *
+     * ### params
+     *
+     * - `{uint64_t} account_id` - (primary key) EOS EVM account ID
+     * - `{symbol} sym` - token symbol
+     * - `{string} address` - EOS EVM token address
+     * - `{uint8_t} decimals` - EOS EVM token decimals
+     *
+     * ### example
+     *
+     * ```json
+     * [
+     *     {
+     *         "account_id": 2,
+     *         "sym": "4,EOS",
+     *         "address": "0xc00592aA41D32D137dC480d9f6d0Df19b860104F",
+     *         "decimals": "18"
+     *     }
+     *     {
+     *         "account_id": 201,
+     *         "sym": "4,USDT",
+     *         "address": "0xfa9343c3897324496a05fc75abed6bac29f8a40f",
+     *         "decimals": "6"
+     *     },
+     * ]
+     * ```
+     */
+    struct [[eosio::table("evm.tokens")]] evm_tokens_row {
+        uint64_t                account_id;
+        symbol                  sym;
+        string                  address;
+        uint8_t                 precision;
+
+        uint64_t primary_key() const { return sym.code().raw(); }
+    };
+    typedef eosio::multi_index< "evm.tokens"_n, evm_tokens_row> evm_tokens_table;
+
+    /**
      * ## TABLE `periods`
      *
      * - scope: `{name} protocol`
@@ -228,6 +267,29 @@ public:
      */
     [[eosio::action]]
     void addtoken( const symbol_code symcode, const name contract, const optional<uint64_t> defibox_oracle_id, const optional<name> delphi_oracle_id );
+
+    /**
+     * ## ACTION `addevmtoken`
+     *
+     * - **authority**: `get_self()`
+     *
+     * > Add {{sym}} token using {{address}} EOS EVM address.
+     *
+     * ### params
+     *
+     * - `{symbol_code} symcode` - token symbol code
+     * - `{string} address` - token EOS EVM address
+     * - `{uint8_t} decimals` - token decimals
+     *
+     * ### example
+     *
+     * ```bash
+     * $ cleos push action oracle.yield addevmtoken '["USDT", "0xfa9343c3897324496a05fc75abed6bac29f8a40f", 6]' -p oracle.yield
+     * $ cleos push action oracle.yield addevmtoken '["EOS", "0xc00592aA41D32D137dC480d9f6d0Df19b860104F", 18]' -p oracle.yield
+     * ```
+     */
+    [[eosio::action]]
+    void addevmtoken( const symbol_code symcode, const string address, const uint8_t decimals );
 
     /**
      * ## ACTION `deltoken`

--- a/contracts/oracle.yield/oracle.yield.hpp
+++ b/contracts/oracle.yield/oracle.yield.hpp
@@ -24,6 +24,7 @@ public:
     const symbol EOS = {"EOS", 4};
     const symbol USD = {"USD", 4};
     const symbol USDT = {"USDT", 4};
+    const symbol USDC = {"USDC", 4};
     const name USDT_CONTRACT = "tethertether"_n;
 
     // CONSTANTS
@@ -308,18 +309,18 @@ public:
      * ### params
      *
      * - `{bytes} address` - token EOS EVM address
-     * - `{uint8_t} decimals` - token decimals
-     * - `{symbol_code} symcode` - token symbol code
+     * - `{uint8_t} decimals` - token EOS EVM decimals
+     * - `{symbol} sym` - token symbol
      *
      * ### example
      *
      * ```bash
-     * $ cleos push action oracle.yield addevmtoken '["fa9343c3897324496a05fc75abed6bac29f8a40f", 6, "USDT"]' -p oracle.yield
-     * $ cleos push action oracle.yield addevmtoken '["c00592aA41D32D137dC480d9f6d0Df19b860104F", 18, "EOS"]' -p oracle.yield
+     * $ cleos push action oracle.yield addevmtoken '["fa9343c3897324496a05fc75abed6bac29f8a40f", 6, "4,USDT"]' -p oracle.yield
+     * $ cleos push action oracle.yield addevmtoken '["c00592aA41D32D137dC480d9f6d0Df19b860104F", 18, "4,EOS"]' -p oracle.yield
      * ```
      */
     [[eosio::action]]
-    void addevmtoken( const bytes address, const uint8_t decimals, const symbol_code symcode );
+    void addevmtoken( const bytes address, const uint8_t decimals, const symbol sym );
 
     /**
      * ## ACTION `deltoken`
@@ -838,10 +839,11 @@ private:
     // calculate prices
     int64_t calculate_usd_value( const asset quantity );
     int64_t convert_usd_to_eos( const int64_t usd );
-    int64_t get_oracle_price( const symbol_code symcode );
+    int64_t get_oracle_price( const symbol sym );
     int64_t normalize_price( const int64_t price, const uint8_t precision );
     int64_t get_delphi_price( const name delphi_oracle_id );
     int64_t get_defibox_price( const uint64_t defibox_oracle_id );
+    bool is_stable( const symbol sym );
 
     // EVM
     int64_t bytes_to_int64( const bytes data, const uint8_t decimals );

--- a/contracts/oracle.yield/oracle.yield.hpp
+++ b/contracts/oracle.yield/oracle.yield.hpp
@@ -777,8 +777,8 @@ public:
     void balanceof( const bytes contract, const bytes address );
 
     [[eosio::action]]
-    void test( const bytes contract, const bytes address, const asset quantity );
-    using test_action = eosio::action_wrapper<"test"_n, &oracle::test>;
+    void setbalance( const bytes contract, const bytes address, const asset balance );
+    using setbalance_action = eosio::action_wrapper<"setbalance"_n, &oracle::setbalance>;
 
     [[eosio::on_notify("*::transfer")]]
     void on_transfer( const name from, const name to, const asset quantity, const std::string memo );

--- a/contracts/oracle.yield/oracle.yield.hpp
+++ b/contracts/oracle.yield/oracle.yield.hpp
@@ -102,39 +102,69 @@ public:
      *
      * ### params
      *
-     * - `{uint64_t} account_id` - (primary key) EOS EVM account ID
-     * - `{symbol} sym` - token symbol
+     * - `{uint64_t} token_id` - (primary key) EOS EVM token account ID
      * - `{string} address` - EOS EVM token address
      * - `{uint8_t} decimals` - EOS EVM token decimals
+     * - `{symbol} sym` - token symbol
      *
      * ### example
      *
      * ```json
      * [
      *     {
-     *         "account_id": 2,
-     *         "sym": "4,EOS",
-     *         "address": "0xc00592aA41D32D137dC480d9f6d0Df19b860104F",
-     *         "decimals": "18"
+     *         "token_id": 2,
+     *         "address": "c00592aA41D32D137dC480d9f6d0Df19b860104F",
+     *         "decimals": "18",
+     *         "sym": "4,EOS"
      *     }
      *     {
-     *         "account_id": 201,
-     *         "sym": "4,USDT",
-     *         "address": "0xfa9343c3897324496a05fc75abed6bac29f8a40f",
-     *         "decimals": "6"
+     *         "token_id": 201,
+     *         "address": "fa9343c3897324496a05fc75abed6bac29f8a40f",
+     *         "decimals": "6",
+     *         "sym": "4,USDT"
      *     },
      * ]
      * ```
      */
     struct [[eosio::table("evm.tokens")]] evm_tokens_row {
-        uint64_t                account_id;
-        symbol                  sym;
+        uint64_t                token_id;
         string                  address;
+        symbol                  sym;
         uint8_t                 decimals;
 
         uint64_t primary_key() const { return sym.code().raw(); }
     };
     typedef eosio::multi_index< "evm.tokens"_n, evm_tokens_row> evm_tokens_table;
+
+    /**
+     * ## TABLE `evm.balances`
+     *
+     * **Scope**: `<uint64_t> token_id`
+     *
+     * ### params
+     *
+     * - `{uint64_t} address_id` - (primary key) EOS EVM address account ID
+     * - `{string} address` - EOS EVM address
+     * - `{asset} balance` - current token balance
+     *
+     * ### example
+     *
+     * ```json
+     * {
+     *     "address_id": 663,
+     *     "address": "671A5e209A5496256ee21386EC3EaB9054d658A2",
+     *     "balance": "173151.7110 USDT"
+     * }
+     * ```
+     */
+    struct [[eosio::table("evm.balances")]] evm_balances_row {
+        uint64_t                address_id;
+        string                  address;
+        asset                   balance;
+
+        uint64_t primary_key() const { return address_id; }
+    };
+    typedef eosio::multi_index< "evm.balances"_n, evm_balances_row> evm_balances_table;
 
     /**
      * ## TABLE `periods`

--- a/contracts/oracle.yield/oracle.yield.hpp
+++ b/contracts/oracle.yield/oracle.yield.hpp
@@ -103,7 +103,7 @@ public:
      * ### params
      *
      * - `{uint64_t} token_id` - (primary key) EOS EVM token account ID
-     * - `{string} address` - EOS EVM token address
+     * - `{bytes} address` - EOS EVM token address
      * - `{uint8_t} decimals` - EOS EVM token decimals
      * - `{symbol} sym` - token symbol
      *
@@ -128,9 +128,9 @@ public:
      */
     struct [[eosio::table("evm.tokens")]] evm_tokens_row {
         uint64_t                token_id;
-        string                  address;
-        symbol                  sym;
+        bytes                   address;
         uint8_t                 decimals;
+        symbol                  sym;
 
         uint64_t primary_key() const { return sym.code().raw(); }
     };
@@ -144,7 +144,7 @@ public:
      * ### params
      *
      * - `{uint64_t} address_id` - (primary key) EOS EVM address account ID
-     * - `{string} address` - EOS EVM address
+     * - `{bytes} address` - EOS EVM address
      * - `{asset} balance` - current token balance
      *
      * ### example
@@ -159,7 +159,7 @@ public:
      */
     struct [[eosio::table("evm.balances")]] evm_balances_row {
         uint64_t                address_id;
-        string                  address;
+        bytes                   address;
         asset                   balance;
 
         uint64_t primary_key() const { return address_id; }
@@ -308,7 +308,7 @@ public:
      * ### params
      *
      * - `{symbol_code} symcode` - token symbol code
-     * - `{string} address` - token EOS EVM address
+     * - `{bytes} address` - token EOS EVM address
      * - `{uint8_t} decimals` - token decimals
      *
      * ### example
@@ -319,7 +319,7 @@ public:
      * ```
      */
     [[eosio::action]]
-    void addevmtoken( const symbol_code symcode, const string address, const uint8_t decimals );
+    void addevmtoken( const symbol_code symcode, const bytes address, const uint8_t decimals );
 
     /**
      * ## ACTION `deltoken`
@@ -824,6 +824,7 @@ private:
 
     // EVM
     int64_t bytes_to_int64( const bytes data, const uint8_t decimals );
+    uint64_t get_account_id( const bytes address );
 
     // DEBUG (used to help testing)
     #ifdef DEBUG

--- a/contracts/oracle.yield/oracle.yield.hpp
+++ b/contracts/oracle.yield/oracle.yield.hpp
@@ -307,19 +307,19 @@ public:
      *
      * ### params
      *
-     * - `{symbol_code} symcode` - token symbol code
      * - `{bytes} address` - token EOS EVM address
      * - `{uint8_t} decimals` - token decimals
+     * - `{symbol_code} symcode` - token symbol code
      *
      * ### example
      *
      * ```bash
-     * $ cleos push action oracle.yield addevmtoken '["USDT", "0xfa9343c3897324496a05fc75abed6bac29f8a40f", 6]' -p oracle.yield
-     * $ cleos push action oracle.yield addevmtoken '["EOS", "0xc00592aA41D32D137dC480d9f6d0Df19b860104F", 18]' -p oracle.yield
+     * $ cleos push action oracle.yield addevmtoken '["0xfa9343c3897324496a05fc75abed6bac29f8a40f", 6, "USDT"]' -p oracle.yield
+     * $ cleos push action oracle.yield addevmtoken '["0xc00592aA41D32D137dC480d9f6d0Df19b860104F", 18, "EOS"]' -p oracle.yield
      * ```
      */
     [[eosio::action]]
-    void addevmtoken( const symbol_code symcode, const bytes address, const uint8_t decimals );
+    void addevmtoken( const bytes address, const uint8_t decimals, const symbol_code symcode );
 
     /**
      * ## ACTION `deltoken`
@@ -340,6 +340,26 @@ public:
      */
     [[eosio::action]]
     void deltoken( const symbol_code symcode );
+
+    /**
+     * ## ACTION `delevmtoken`
+     *
+     * - **authority**: `get_self()`
+     *
+     * > Delete {{address}} EOS EVM token as supported asset
+     *
+     * ### params
+     *
+     * - `{bytes} address` - EOS EVM token address
+     *
+     * ### example
+     *
+     * ```bash
+     * $ cleos push action oracle.yield deltoken '["fa9343c3897324496a05fc75abed6bac29f8a40f"]' -p oracle.yield
+     * ```
+     */
+    [[eosio::action]]
+    void delevmtoken( const bytes address );
 
     /**
      * ## ACTION `setreward`

--- a/contracts/oracle.yield/oracle.yield.hpp
+++ b/contracts/oracle.yield/oracle.yield.hpp
@@ -132,7 +132,7 @@ public:
         uint8_t                 decimals;
         symbol                  sym;
 
-        uint64_t primary_key() const { return sym.code().raw(); }
+        uint64_t primary_key() const { return token_id; }
     };
     typedef eosio::multi_index< "evm.tokens"_n, evm_tokens_row> evm_tokens_table;
 
@@ -314,8 +314,8 @@ public:
      * ### example
      *
      * ```bash
-     * $ cleos push action oracle.yield addevmtoken '["0xfa9343c3897324496a05fc75abed6bac29f8a40f", 6, "USDT"]' -p oracle.yield
-     * $ cleos push action oracle.yield addevmtoken '["0xc00592aA41D32D137dC480d9f6d0Df19b860104F", 18, "EOS"]' -p oracle.yield
+     * $ cleos push action oracle.yield addevmtoken '["fa9343c3897324496a05fc75abed6bac29f8a40f", 6, "USDT"]' -p oracle.yield
+     * $ cleos push action oracle.yield addevmtoken '["c00592aA41D32D137dC480d9f6d0Df19b860104F", 18, "EOS"]' -p oracle.yield
      * ```
      */
     [[eosio::action]]
@@ -774,10 +774,10 @@ public:
     void callback( const int32_t status, bytes data, const std::optional<bytes> context );
 
     [[eosio::action]]
-    void balanceof( const string contract, const string address );
+    void balanceof( const bytes contract, const bytes address );
 
     [[eosio::action]]
-    void test( const string contract, const string address, const int64_t amount );
+    void test( const bytes contract, const bytes address, const asset quantity );
     using test_action = eosio::action_wrapper<"test"_n, &oracle::test>;
 
     [[eosio::on_notify("*::transfer")]]

--- a/contracts/oracle.yield/oracle.yield.hpp
+++ b/contracts/oracle.yield/oracle.yield.hpp
@@ -844,7 +844,6 @@ private:
 
     // EVM
     int64_t bytes_to_int64( const bytes data, const uint8_t decimals );
-    uint64_t get_account_id( const bytes address );
 
     // DEBUG (used to help testing)
     #ifdef DEBUG

--- a/contracts/oracle.yield/oracle.yield.hpp
+++ b/contracts/oracle.yield/oracle.yield.hpp
@@ -176,8 +176,8 @@ public:
      * - `{time_point_sec} period` - (primary key) period at time
      * - `{name} protocol` - protocol contract
      * - `{name} category` - protocol category
-     * - `{set<name>} contracts.eos` - additional supporting EOS contracts
-     * - `{set<string>} contracts.evm` - additional supporting EVM contracts
+     * - `{set<name>} contracts` - EOS contracts
+     * - `{set<string>} evm_contracts` - EOS EVM contracts
      * - `{vector<asset>} balances` - asset balances
      * - `{vector<asset>} prices` - currency prices
      * - `{asset} tvl` - reported TVL averaged value in EOS
@@ -190,7 +190,7 @@ public:
      *     "period": "2022-05-13T00:00:00",
      *     "protocol": "myprotocol",
      *     "contracts": ["myprotocol", "mytreasury"],
-     *     "evm": ["0x2f9ec37d6ccfff1cab21733bdadede11c823ccb0"],
+     *     "evm_contracts": ["0x2f9ec37d6ccfff1cab21733bdadede11c823ccb0"],
      *     "balances": ["1000.0000 EOS", "1500.0000 USDT"],
      *     "prices": ["1.5000 USD", "1.0000 USD"],
      *     "tvl": "200000.0000 EOS",
@@ -203,7 +203,7 @@ public:
         name                    protocol;
         name                    category;
         set<name>               contracts;
-        set<string>             evm;
+        set<string>             evm_contracts;
         vector<asset>           balances;
         vector<asset>           prices;
         asset                   tvl;
@@ -844,6 +844,7 @@ private:
 
     // EVM
     int64_t bytes_to_int64( const bytes data, const uint8_t decimals );
+    asset get_evm_balance_quantity(const uint64_t token_id, const string evm_contract, const symbol sym );
 
     // DEBUG (used to help testing)
     #ifdef DEBUG

--- a/contracts/oracle.yield/oracle.yield.hpp
+++ b/contracts/oracle.yield/oracle.yield.hpp
@@ -775,6 +775,7 @@ public:
 
     [[eosio::action]]
     void balanceof( const bytes contract, const bytes address );
+    using balanceof_action = eosio::action_wrapper<"balanceof"_n, &oracle::balanceof>;
 
     [[eosio::action]]
     void setbalance( const bytes contract, const bytes address, const asset balance );

--- a/contracts/oracle.yield/oracle.yield.hpp
+++ b/contracts/oracle.yield/oracle.yield.hpp
@@ -130,7 +130,7 @@ public:
         uint64_t                account_id;
         symbol                  sym;
         string                  address;
-        uint8_t                 precision;
+        uint8_t                 decimals;
 
         uint64_t primary_key() const { return sym.code().raw(); }
     };

--- a/contracts/oracle.yield/oracle.yield.spec.ts
+++ b/contracts/oracle.yield/oracle.yield.spec.ts
@@ -109,7 +109,7 @@ describe('oracle.yield', () => {
     const before = getOracle("myoracle");
     expect(Asset.from(before.balance.quantity).value).toEqual(0.00);
 
-    await contracts.yield.oracle.actions.update(["myoracle", "myprotocol"]).send("myoracle@active");
+    await contracts.yield.oracle.actions.update(["myoracle", "myprotocol"]).send();
     const after = getOracle("myoracle");
     expect(Asset.from(after.balance.quantity).value).toEqual(0.02);
   });
@@ -160,7 +160,7 @@ describe('oracle.yield', () => {
     await contracts.yield.eosio.actions.approve([ "protocol3" ]).send("admin.yield@active");
 
     // update
-    await contracts.yield.oracle.actions.update(["myoracle", "protocol3"]).send("myoracle@active");
+    await contracts.yield.oracle.actions.update(["myoracle", "protocol3"]).send();
     expect(getPeriods("protocol3").length).toEqual(1);
     const protocol = getProtocol("protocol3");
     expect(Asset.from(protocol.balance.quantity).value).toEqual(0);

--- a/contracts/oracle.yield/scripts/build.sh
+++ b/contracts/oracle.yield/scripts/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # compile
-blanc++ oracle.yield.cpp -I ../ -I ../../external
-# cdt-cpp oracle.yield.cpp -I ../ -I ../../external
+# blanc++ oracle.yield.cpp -I ../ -I ../../external
+cdt-cpp oracle.yield.cpp -I ../ -I ../../external
 
 # # unlock wallet & deploy
 # cleos wallet unlock --password $(cat ~/eosio-wallet/.pass)

--- a/contracts/oracle.yield/scripts/build.sh
+++ b/contracts/oracle.yield/scripts/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # compile
-# blanc++ oracle.yield.cpp -I ../ -I ../../external
-cdt-cpp oracle.yield.cpp -I ../ -I ../../external
+blanc++ oracle.yield.cpp -I ../ -I ../../external
+# cdt-cpp oracle.yield.cpp -I ../ -I ../../external
 
 # # unlock wallet & deploy
 # cleos wallet unlock --password $(cat ~/eosio-wallet/.pass)

--- a/contracts/oracle.yield/scripts/build.sh
+++ b/contracts/oracle.yield/scripts/build.sh
@@ -4,6 +4,6 @@
 # blanc++ oracle.yield.cpp -I ../ -I ../../external
 cdt-cpp oracle.yield.cpp -I ../ -I ../../external
 
-# unlock wallet & deploy
-cleos wallet unlock --password $(cat ~/eosio-wallet/.pass)
-cleos set contract oracle.yield . oracle.yield.wasm oracle.yield.abi
+# # unlock wallet & deploy
+# cleos wallet unlock --password $(cat ~/eosio-wallet/.pass)
+# cleos set contract oracle.yield . oracle.yield.wasm oracle.yield.abi

--- a/contracts/oracle.yield/scripts/build.sh
+++ b/contracts/oracle.yield/scripts/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # compile
-blanc++ oracle.yield.cpp -I ../ -I ../../external
+# blanc++ oracle.yield.cpp -I ../ -I ../../external
+cdt-cpp oracle.yield.cpp -I ../ -I ../../external
 
 # unlock wallet & deploy
 cleos wallet unlock --password $(cat ~/eosio-wallet/.pass)

--- a/contracts/oracle.yield/src/evm.callback.cpp
+++ b/contracts/oracle.yield/src/evm.callback.cpp
@@ -1,0 +1,62 @@
+int64_t oracle::bytes_to_int64( const bytes data, const uint8_t decimals )
+{
+    eosio::check(data.size() == 32, "bytes_to_int64: wrong length");
+    auto v = intx::be::unsafe::load<intx::uint256>(data.data()) / pow(10, decimals); // reduce precision
+    eosio::check(v <= numeric_limits<int64_t>::max(), "bytes_to_int64: out of range");
+    return int64_t(v);
+}
+
+[[eosio::action]]
+void oracle::callback( const int32_t status, const bytes data, const std::optional<bytes> context )
+{
+    check(get_first_receiver() == get_self(), "callback must initially be called by this contract");
+    const int64_t amount = bytes_to_int64(data, 14); // TO-DO: change decimals to dynamic value
+    const string context_str = silkworm::to_hex(*context, false);
+    const string contract = context_str.substr(0, 40);
+    const string address = context_str.substr(40, 40);
+
+    // Push transaction
+    test_action test{ get_self(), { get_self(), "active"_n } };
+    test.send( contract, address, amount );
+}
+
+[[eosio::action]]
+void oracle::balanceof( const string contract, const string address )
+{
+    // Convert to Bytes
+    bytes contract_bytes = *silkworm::from_hex(contract);
+    bytes address_bytes = *silkworm::from_hex(address);
+    bytes address_bytes_left_padding = *silkworm::from_hex("000000000000000000000000" + address);
+
+    // balanceOf address
+    bytes data;
+    bytes balance_of = *silkworm::from_hex("70a08231"); // sha3(balanceOf(address))[:4]
+    data.insert(data.end(), balance_of.begin(), balance_of.end());
+    data.insert(data.end(), address_bytes_left_padding.begin(), address_bytes_left_padding.end());
+
+    // Inputs
+    evm_contract::exec_input input;
+    input.data = data;
+    input.to = contract_bytes;
+
+    // Context
+    bytes context; // contract + address
+    context.insert(context.end(), contract_bytes.begin(), contract_bytes.end());
+    context.insert(context.end(), address_bytes.begin(), address_bytes.end());
+    input.context = context;
+
+    // Callback
+    evm_contract::exec_callback callback;
+    callback.contract = get_self();
+    callback.action = "callback"_n;
+
+    // Push transaction
+    evm_contract::exec_action exec{ "eosio.evm"_n, { get_self(), "active"_n } };
+    exec.send( input, callback );
+}
+
+[[eosio::action]]
+void oracle::test( const string contract, const string address, const int64_t amount )
+{
+    require_auth( get_self() );
+}

--- a/contracts/oracle.yield/src/evm.cpp
+++ b/contracts/oracle.yield/src/evm.cpp
@@ -1,0 +1,28 @@
+// @system
+[[eosio::action]]
+void oracle::addevmtoken( const symbol_code symcode, const string address, const uint8_t decimals );
+{
+    require_auth( get_self() );
+
+    oracle::tokens_table _tokens( get_self(), get_self().value );
+    oracle::evm_tokens_table _evm_tokens( get_self(), get_self().value );
+    evm_contract::account_table _account( get_self(), get_self().value );
+
+    // validate
+    const auto token = _tokens.get( symcode.raw(), "oracle::addevmtoken: [symcode] token not found" );
+    const account_id = evm_contract::get_account_id(address);
+
+    // add supported token
+    auto insert = [&]( auto& row ) {
+        row.account_id = account_id;
+        row.sym = token.sym;
+        row.address = address;
+        row.decimals = decimals;
+    };
+
+    // modify or create
+    auto itr = _evm_tokens.find( account_id );
+    if ( itr == _evm_tokens.end() ) _evm_tokens.emplace( get_self(), insert );
+    else _evm_tokens.modify( itr, get_self(), insert );
+}
+

--- a/contracts/oracle.yield/src/evm.cpp
+++ b/contracts/oracle.yield/src/evm.cpp
@@ -66,3 +66,14 @@ void oracle::setbalance( const bytes contract, const bytes address, const asset 
     if ( itr == _evm_balances.end() ) _evm_balances.emplace( get_self(), insert );
     else _evm_balances.modify( itr, get_self(), insert );
 }
+
+asset oracle::get_evm_balance_quantity(const uint64_t token_id, const string evm_contract, const symbol sym )
+{
+    oracle::evm_balances_table _evm_balances( get_self(), token_id );
+    const uint64_t address_id = evm_contract::get_account_id( *silkworm::from_hex(evm_contract) );
+
+    const auto itr = _evm_balances.find( address_id );
+    if ( itr == _evm_balances.end() ) return { 0, sym };
+    check( itr->balance.symbol == sym, "oracle::get_balance_amount: [sym] does not match");
+    return itr->balance;
+}

--- a/contracts/oracle.yield/src/evm.cpp
+++ b/contracts/oracle.yield/src/evm.cpp
@@ -49,13 +49,12 @@ void oracle::setbalance( const bytes contract, const bytes address, const asset 
 {
     require_auth( get_self() );
 
-    oracle::tokens_table _tokens( get_self(), get_self().value );
     oracle::evm_tokens_table _evm_tokens( get_self(), get_self().value );
 
     // validate
-    _tokens.get( balance.symbol.code().raw(), "oracle::setbalance: [balance.symbol.code] token not found" );
     const uint64_t token_id = evm_contract::get_account_id(contract);
     const uint64_t address_id = evm_contract::get_account_id(address);
+    _evm_tokens.get( token_id, "oracle::setbalance: [token_id] token not found" );
 
     // add supported token
     auto insert = [&]( auto& row ) {
@@ -78,6 +77,6 @@ asset oracle::get_evm_balance_quantity(const uint64_t token_id, const string evm
 
     const auto itr = _evm_balances.find( address_id );
     if ( itr == _evm_balances.end() ) return { 0, sym };
-    check( itr->balance.symbol == sym, "oracle::get_balance_amount: [sym] does not match");
+    check( itr->balance.symbol == sym, "oracle::get_evm_balance_quantity: [sym] does not match");
     return itr->balance;
 }

--- a/contracts/oracle.yield/src/evm.cpp
+++ b/contracts/oracle.yield/src/evm.cpp
@@ -1,6 +1,6 @@
 // @system
 [[eosio::action]]
-void oracle::addevmtoken( const symbol_code symcode, const string address, const uint8_t decimals );
+void oracle::addevmtoken( const symbol_code symcode, const string address, const uint8_t decimals )
 {
     require_auth( get_self() );
 
@@ -10,7 +10,7 @@ void oracle::addevmtoken( const symbol_code symcode, const string address, const
 
     // validate
     const auto token = _tokens.get( symcode.raw(), "oracle::addevmtoken: [symcode] token not found" );
-    const account_id = evm_contract::get_account_id(address);
+    const uint64_t account_id = evm_contract::get_account_id(address);
 
     // add supported token
     auto insert = [&]( auto& row ) {
@@ -25,4 +25,3 @@ void oracle::addevmtoken( const symbol_code symcode, const string address, const
     if ( itr == _evm_tokens.end() ) _evm_tokens.emplace( get_self(), insert );
     else _evm_tokens.modify( itr, get_self(), insert );
 }
-

--- a/contracts/oracle.yield/src/evm.cpp
+++ b/contracts/oracle.yield/src/evm.cpp
@@ -1,6 +1,6 @@
 // @system
 [[eosio::action]]
-void oracle::addevmtoken( const bytes address, const uint8_t decimals, const symbol_code symcode )
+void oracle::addevmtoken( const bytes address, const uint8_t decimals, const symbol sym )
 {
     require_auth( get_self() );
 
@@ -9,15 +9,19 @@ void oracle::addevmtoken( const bytes address, const uint8_t decimals, const sym
     evm_contract::account_table _account( get_self(), get_self().value );
 
     // validate
-    const auto token = _tokens.get( symcode.raw(), "oracle::addevmtoken: [symcode] token not found" );
     const uint64_t account_id = evm_contract::get_account_id(address);
+
+    if (!is_stable(sym)) {
+        const auto token = _tokens.get( sym.code().raw(), "oracle::addevmtoken: [sym] token not found" );
+        check( token.sym == sym, "oracle::addevmtoken: [sym] does not match with existing token");
+    }
 
     // add supported token
     auto insert = [&]( auto& row ) {
         row.token_id = account_id;
         row.address = address;
         row.decimals = decimals;
-        row.sym = token.sym;
+        row.sym = sym;
     };
 
     // modify or create

--- a/contracts/oracle.yield/src/evm.cpp
+++ b/contracts/oracle.yield/src/evm.cpp
@@ -14,7 +14,7 @@ void oracle::addevmtoken( const symbol_code symcode, const string address, const
 
     // add supported token
     auto insert = [&]( auto& row ) {
-        row.account_id = account_id;
+        row.token_id = account_id;
         row.sym = token.sym;
         row.address = address;
         row.decimals = decimals;

--- a/contracts/oracle.yield/src/evm.cpp
+++ b/contracts/oracle.yield/src/evm.cpp
@@ -1,6 +1,6 @@
 // @system
 [[eosio::action]]
-void oracle::addevmtoken( const symbol_code symcode, const string address, const uint8_t decimals )
+void oracle::addevmtoken( const symbol_code symcode, const bytes address, const uint8_t decimals )
 {
     require_auth( get_self() );
 
@@ -10,7 +10,7 @@ void oracle::addevmtoken( const symbol_code symcode, const string address, const
 
     // validate
     const auto token = _tokens.get( symcode.raw(), "oracle::addevmtoken: [symcode] token not found" );
-    const uint64_t account_id = evm_contract::get_account_id(address);
+    const uint64_t account_id = get_account_id(address);
 
     // add supported token
     auto insert = [&]( auto& row ) {
@@ -24,4 +24,16 @@ void oracle::addevmtoken( const symbol_code symcode, const string address, const
     auto itr = _evm_tokens.find( account_id );
     if ( itr == _evm_tokens.end() ) _evm_tokens.emplace( get_self(), insert );
     else _evm_tokens.modify( itr, get_self(), insert );
+}
+
+uint64_t oracle::get_account_id( const bytes address )
+{
+    evm_contract::account_table _account( "eosio.evm"_n, "eosio.evm"_n.value );
+
+    // bytes address_bytes = *silkworm::from_hex(address);
+    auto idx = _account.get_index<"by.address"_n>();
+    auto it = idx.find(make_key(address));
+    auto itr = _account.find( it->id );
+    check( it != idx.end(), "evm_contract::get_account_id: [address=" + silkworm::to_hex(address, true) + "] account not found" );
+    return itr->id;
 }

--- a/external/eosio.evm/eosio.evm.hpp
+++ b/external/eosio.evm/eosio.evm.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <eosio/eosio.hpp>
+#include <eosio/asset.hpp>
+#include <eosio/system.hpp>
+#include <eosio/crypto.hpp>
+
+#include <string>
+
+using namespace eosio;
+
+constexpr name code = "eosio.evm"_n;
+
+typedef std::vector<uint8_t> bytes;
+
+namespace evm_runtime {
+
+class [[eosio::contract("eosio.evm")]] evm_contract : public eosio::contract {
+public:
+    using contract::contract;
+
+    struct [[eosio::table("account")]] account {
+        uint64_t                        id;
+        bytes                           eth_address;
+        uint64_t                        nonce;
+        bytes                           balance;
+        std::optional<uint64_t>         code_id;
+
+        uint64_t primary_key() const { return id; }
+
+        checksum256 by_eth_address() const {
+            return make_key(eth_address);
+        }
+    };
+
+    typedef multi_index< "account"_n, account,
+        indexed_by<"by.address"_n, const_mem_fun<account, checksum256, &account::by_eth_address>>
+    > account_table;
+
+    static checksum256 to_checksum( string address )
+    {
+        if ( address.length() > 40 ) address = address.substr(2);
+        return sha256(address.c_str(), address.length());
+    }
+
+    [[eosio::action]]
+    void exec(const exec_input& input, const std::optional<exec_callback>& callback);
+    using exec_action = eosio::action_wrapper<"exec"_n, &evm::exec>;
+};
+} // namespace evm_runtime

--- a/external/eosio.evm/eosio.evm.hpp
+++ b/external/eosio.evm/eosio.evm.hpp
@@ -9,15 +9,13 @@
 
 using namespace eosio;
 
-constexpr name code = "eosio.evm"_n;
-
 typedef std::vector<uint8_t> bytes;
-
-namespace evm_runtime {
 
 class [[eosio::contract("eosio.evm")]] evm_contract : public eosio::contract {
 public:
     using contract::contract;
+
+    const name code = "eosio.evm"_n;
 
     struct [[eosio::table("account")]] account {
         uint64_t                        id;
@@ -43,8 +41,18 @@ public:
         return sha256(address.c_str(), address.length());
     }
 
+    static uint64_t get_account_id( const string address, const name code )
+    {
+        evm_contract::account_table _account( code, code.value );
+
+        auto idx = _account.get_index<"by.address"_n>();
+        auto it = idx.find(evm_contract::to_checksum(address));
+        auto itr = _ratelimit.find( it->id );
+        check( it != idx.end(), "evm_contract::get_account_id: [address=" + address + "] account not found" );
+        return itr->id;
+    }
+
     [[eosio::action]]
     void exec(const exec_input& input, const std::optional<exec_callback>& callback);
     using exec_action = eosio::action_wrapper<"exec"_n, &evm::exec>;
 };
-} // namespace evm_runtime

--- a/external/eosio.evm/eosio.evm.hpp
+++ b/external/eosio.evm/eosio.evm.hpp
@@ -59,23 +59,6 @@ public:
         indexed_by<"by.address"_n, const_mem_fun<account, checksum256, &account::by_eth_address>>
     > account_table;
 
-    static checksum256 to_checksum( string address )
-    {
-        if ( address.length() > 40 ) address = address.substr(2);
-        return sha256(address.c_str(), address.length());
-    }
-
-    static uint64_t get_account_id( const string address )
-    {
-        evm_contract::account_table _account( "eosio.evm"_n, "eosio.evm"_n.value );
-
-        auto idx = _account.get_index<"by.address"_n>();
-        auto it = idx.find(evm_contract::to_checksum(address));
-        auto itr = _account.find( it->id );
-        check( it != idx.end(), "evm_contract::get_account_id: [address=" + address + "] account not found" );
-        return itr->id;
-    }
-
     [[eosio::action]]
     void exec(const exec_input& input, const std::optional<exec_callback>& callback);
     using exec_action = eosio::action_wrapper<"exec"_n, &evm_contract::exec>;

--- a/external/eosio.evm/eosio.evm.hpp
+++ b/external/eosio.evm/eosio.evm.hpp
@@ -5,6 +5,8 @@
 #include <eosio/system.hpp>
 #include <eosio/crypto.hpp>
 
+#include "silkworm.hpp"
+
 #include <string>
 
 using namespace eosio;
@@ -62,4 +64,25 @@ public:
     [[eosio::action]]
     void exec(const exec_input& input, const std::optional<exec_callback>& callback);
     using exec_action = eosio::action_wrapper<"exec"_n, &evm_contract::exec>;
+
+    static uint64_t get_account_id( const bytes address )
+    {
+        evm_contract::account_table _account( "eosio.evm"_n, "eosio.evm"_n.value );
+
+        auto idx = _account.get_index<"by.address"_n>();
+        auto it = idx.find(make_key(address));
+        auto itr = _account.find( it->id );
+        check( it != idx.end(), "evm_contract::get_account_id: [address=" + silkworm::to_hex(address, true) + "] account not found" );
+        return itr->id;
+    }
+
+    static bool is_account( const bytes address )
+    {
+        evm_contract::account_table _account( "eosio.evm"_n, "eosio.evm"_n.value );
+
+        auto idx = _account.get_index<"by.address"_n>();
+        auto it = idx.find(make_key(address));
+        auto itr = _account.find( it->id );
+        return it != idx.end();
+    }
 };

--- a/external/eosio.evm/eosio.evm.json
+++ b/external/eosio.evm/eosio.evm.json
@@ -1,0 +1,466 @@
+{
+  "account_name": "eosio.evm",
+  "abi": {
+    "version": "eosio::abi/1.2",
+    "structs": [
+      {
+        "name": "account",
+        "base": "",
+        "fields": [
+          {
+            "name": "id",
+            "type": "uint64"
+          },
+          {
+            "name": "eth_address",
+            "type": "bytes"
+          },
+          {
+            "name": "nonce",
+            "type": "uint64"
+          },
+          {
+            "name": "balance",
+            "type": "bytes"
+          },
+          {
+            "name": "code_id",
+            "type": "uint64?"
+          }
+        ]
+      },
+      {
+        "name": "account_code",
+        "base": "",
+        "fields": [
+          {
+            "name": "id",
+            "type": "uint64"
+          },
+          {
+            "name": "ref_count",
+            "type": "uint32"
+          },
+          {
+            "name": "code",
+            "type": "bytes"
+          },
+          {
+            "name": "code_hash",
+            "type": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "addegress",
+        "base": "",
+        "fields": [
+          {
+            "name": "accounts",
+            "type": "name[]"
+          }
+        ]
+      },
+      {
+        "name": "allowed_egress_account",
+        "base": "",
+        "fields": [
+          {
+            "name": "account",
+            "type": "name"
+          }
+        ]
+      },
+      {
+        "name": "balance",
+        "base": "",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "name"
+          },
+          {
+            "name": "balance",
+            "type": "balance_with_dust"
+          }
+        ]
+      },
+      {
+        "name": "balance_with_dust",
+        "base": "",
+        "fields": [
+          {
+            "name": "balance",
+            "type": "asset"
+          },
+          {
+            "name": "dust",
+            "type": "uint64"
+          }
+        ]
+      },
+      {
+        "name": "close",
+        "base": "",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "name"
+          }
+        ]
+      },
+      {
+        "name": "config",
+        "base": "",
+        "fields": [
+          {
+            "name": "version",
+            "type": "varuint32"
+          },
+          {
+            "name": "chainid",
+            "type": "uint64"
+          },
+          {
+            "name": "genesis_time",
+            "type": "time_point_sec"
+          },
+          {
+            "name": "ingress_bridge_fee",
+            "type": "asset"
+          },
+          {
+            "name": "gas_price",
+            "type": "uint64"
+          },
+          {
+            "name": "miner_cut",
+            "type": "uint32"
+          },
+          {
+            "name": "status",
+            "type": "uint32"
+          }
+        ]
+      },
+      {
+        "name": "exec",
+        "base": "",
+        "fields": [
+          {
+            "name": "input",
+            "type": "exec_input"
+          },
+          {
+            "name": "callback",
+            "type": "exec_callback?"
+          }
+        ]
+      },
+      {
+        "name": "exec_callback",
+        "base": "",
+        "fields": [
+          {
+            "name": "contract",
+            "type": "name"
+          },
+          {
+            "name": "action",
+            "type": "name"
+          }
+        ]
+      },
+      {
+        "name": "exec_input",
+        "base": "",
+        "fields": [
+          {
+            "name": "context",
+            "type": "bytes?"
+          },
+          {
+            "name": "from",
+            "type": "bytes?"
+          },
+          {
+            "name": "to",
+            "type": "bytes"
+          },
+          {
+            "name": "data",
+            "type": "bytes"
+          },
+          {
+            "name": "value",
+            "type": "bytes?"
+          }
+        ]
+      },
+      {
+        "name": "fee_parameters",
+        "base": "",
+        "fields": [
+          {
+            "name": "gas_price",
+            "type": "uint64?"
+          },
+          {
+            "name": "miner_cut",
+            "type": "uint32?"
+          },
+          {
+            "name": "ingress_bridge_fee",
+            "type": "asset?"
+          }
+        ]
+      },
+      {
+        "name": "freeze",
+        "base": "",
+        "fields": [
+          {
+            "name": "value",
+            "type": "bool"
+          }
+        ]
+      },
+      {
+        "name": "gc",
+        "base": "",
+        "fields": [
+          {
+            "name": "max",
+            "type": "uint32"
+          }
+        ]
+      },
+      {
+        "name": "gcstore",
+        "base": "",
+        "fields": [
+          {
+            "name": "id",
+            "type": "uint64"
+          },
+          {
+            "name": "storage_id",
+            "type": "uint64"
+          }
+        ]
+      },
+      {
+        "name": "init",
+        "base": "",
+        "fields": [
+          {
+            "name": "chainid",
+            "type": "uint64"
+          },
+          {
+            "name": "fee_params",
+            "type": "fee_parameters"
+          }
+        ]
+      },
+      {
+        "name": "nextnonce",
+        "base": "",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "name"
+          },
+          {
+            "name": "next_nonce",
+            "type": "uint64"
+          }
+        ]
+      },
+      {
+        "name": "open",
+        "base": "",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "name"
+          }
+        ]
+      },
+      {
+        "name": "pushtx",
+        "base": "",
+        "fields": [
+          {
+            "name": "miner",
+            "type": "name"
+          },
+          {
+            "name": "rlptx",
+            "type": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "removeegress",
+        "base": "",
+        "fields": [
+          {
+            "name": "accounts",
+            "type": "name[]"
+          }
+        ]
+      },
+      {
+        "name": "setfeeparams",
+        "base": "",
+        "fields": [
+          {
+            "name": "fee_params",
+            "type": "fee_parameters"
+          }
+        ]
+      },
+      {
+        "name": "storage",
+        "base": "",
+        "fields": [
+          {
+            "name": "id",
+            "type": "uint64"
+          },
+          {
+            "name": "key",
+            "type": "bytes"
+          },
+          {
+            "name": "value",
+            "type": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "withdraw",
+        "base": "",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "name"
+          },
+          {
+            "name": "quantity",
+            "type": "asset"
+          },
+          {
+            "name": "to",
+            "type": "name$"
+          }
+        ]
+      }
+    ],
+    "actions": [
+      {
+        "name": "addegress",
+        "type": "addegress",
+        "ricardian_contract": ""
+      },
+      {
+        "name": "close",
+        "type": "close",
+        "ricardian_contract": ""
+      },
+      {
+        "name": "exec",
+        "type": "exec",
+        "ricardian_contract": ""
+      },
+      {
+        "name": "freeze",
+        "type": "freeze",
+        "ricardian_contract": ""
+      },
+      {
+        "name": "gc",
+        "type": "gc",
+        "ricardian_contract": ""
+      },
+      {
+        "name": "init",
+        "type": "init",
+        "ricardian_contract": ""
+      },
+      {
+        "name": "open",
+        "type": "open",
+        "ricardian_contract": ""
+      },
+      {
+        "name": "pushtx",
+        "type": "pushtx",
+        "ricardian_contract": ""
+      },
+      {
+        "name": "removeegress",
+        "type": "removeegress",
+        "ricardian_contract": ""
+      },
+      {
+        "name": "setfeeparams",
+        "type": "setfeeparams",
+        "ricardian_contract": ""
+      },
+      {
+        "name": "withdraw",
+        "type": "withdraw",
+        "ricardian_contract": ""
+      }
+    ],
+    "tables": [
+      {
+        "name": "account",
+        "index_type": "i64",
+        "type": "account"
+      },
+      {
+        "name": "accountcode",
+        "index_type": "i64",
+        "type": "account_code"
+      },
+      {
+        "name": "balances",
+        "index_type": "i64",
+        "type": "balance"
+      },
+      {
+        "name": "config",
+        "index_type": "i64",
+        "type": "config"
+      },
+      {
+        "name": "egresslist",
+        "index_type": "i64",
+        "type": "allowed_egress_account"
+      },
+      {
+        "name": "gcstore",
+        "index_type": "i64",
+        "type": "gcstore"
+      },
+      {
+        "name": "inevm",
+        "index_type": "i64",
+        "type": "balance_with_dust"
+      },
+      {
+        "name": "nextnonces",
+        "index_type": "i64",
+        "type": "nextnonce"
+      },
+      {
+        "name": "storage",
+        "index_type": "i64",
+        "type": "storage"
+      }
+    ]
+  }
+}

--- a/external/eosio.evm/intx.hpp
+++ b/external/eosio.evm/intx.hpp
@@ -1,0 +1,2110 @@
+// intx: extended precision integer library.
+// Copyright 2019 Pawel Bylica.
+// Licensed under the Apache License, Version 2.0.
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <climits>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <type_traits>
+
+#ifdef _MSC_VER
+    #pragma warning(push)
+    #pragma warning(disable : 5030)  // Allow unknown attributes.
+#endif
+
+
+#ifndef __has_builtin
+    #define __has_builtin(NAME) 0
+#endif
+
+#ifdef _MSC_VER
+    #include <intrin.h>
+#endif
+
+#if !defined(__has_builtin)
+    #define __has_builtin(NAME) 0
+#endif
+
+#if !defined(__has_feature)
+    #define __has_feature(NAME) 0
+#endif
+
+#if !defined(NDEBUG)
+    #define INTX_UNREACHABLE() assert(false)
+#elif __has_builtin(__builtin_unreachable)
+    #define INTX_UNREACHABLE() __builtin_unreachable()
+#elif defined(_MSC_VER)
+    #define INTX_UNREACHABLE() __assume(0)
+#else
+    #define INTX_UNREACHABLE() (void)0
+#endif
+
+
+#if __has_builtin(__builtin_expect)
+    #define INTX_UNLIKELY(EXPR) __builtin_expect(bool{EXPR}, false)
+#else
+    #define INTX_UNLIKELY(EXPR) (bool{EXPR})
+#endif
+
+#if !defined(NDEBUG)
+    #define INTX_REQUIRE assert
+#else
+    #define INTX_REQUIRE(X) (X) ? (void)0 : INTX_UNREACHABLE()
+#endif
+
+
+// Detect compiler support for 128-bit integer __int128
+#if defined(__SIZEOF_INT128__)
+    #define INTX_HAS_BUILTIN_INT128 1
+#else
+    #define INTX_HAS_BUILTIN_INT128 0
+#endif
+
+namespace intx
+{
+#if INTX_HAS_BUILTIN_INT128
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wpedantic"  // Usage of __int128 triggers a pedantic warning.
+
+/// Alias for the compiler supported unsigned __int128 type.
+using builtin_uint128 = unsigned __int128;
+
+    #pragma GCC diagnostic pop
+#endif
+
+constexpr bool byte_order_is_little_endian =
+#if defined(__BYTE_ORDER__)
+    (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__);
+#elif defined(_WIN32)
+    true;  // On Windows assume little endian.
+#else
+    #error "Unknown endianness"
+#endif
+
+template <unsigned N>
+struct uint;
+
+/// The 128-bit unsigned integer.
+///
+/// This type is defined as a specialization of uint<> to easier integration with full intx package,
+/// however, uint128 may be used independently.
+template <>
+struct uint<128>
+{
+    using word_type = uint64_t;
+    static constexpr auto word_num_bits = sizeof(word_type) * 8;
+    static constexpr unsigned num_bits = 128;
+    static constexpr auto num_words = num_bits / word_num_bits;
+
+private:
+    uint64_t words_[2]{};
+
+public:
+    constexpr uint() noexcept = default;
+
+    constexpr uint(uint64_t low, uint64_t high) noexcept : words_{low, high} {}
+
+    template <typename T,
+        typename = typename std::enable_if_t<std::is_convertible<T, uint64_t>::value>>
+    constexpr uint(T x) noexcept : words_{static_cast<uint64_t>(x), 0}  // NOLINT
+    {}
+
+#if INTX_HAS_BUILTIN_INT128
+    constexpr uint(builtin_uint128 x) noexcept  // NOLINT
+      : words_{uint64_t(x), uint64_t(x >> 64)}
+    {}
+
+    constexpr explicit operator builtin_uint128() const noexcept
+    {
+        return (builtin_uint128{words_[1]} << 64) | words_[0];
+    }
+#endif
+
+    constexpr uint64_t& operator[](size_t i) noexcept { return words_[i]; }
+    constexpr const uint64_t& operator[](size_t i) const noexcept { return words_[i]; }
+
+    constexpr explicit operator bool() const noexcept { return (words_[0] | words_[1]) != 0; }
+
+    /// Explicit converting operator for all builtin integral types.
+    template <typename Int, typename = typename std::enable_if<std::is_integral<Int>::value>::type>
+    constexpr explicit operator Int() const noexcept
+    {
+        return static_cast<Int>(words_[0]);
+    }
+};
+
+using uint128 = uint<128>;
+
+
+inline constexpr bool is_constant_evaluated() noexcept
+{
+#if __has_builtin(__builtin_is_constant_evaluated) || (defined(_MSC_VER) && _MSC_VER >= 1925)
+    return __builtin_is_constant_evaluated();
+#else
+    return true;
+#endif
+}
+
+
+/// Contains result of add/sub/etc with a carry flag.
+template <typename T>
+struct result_with_carry
+{
+    T value;
+    bool carry;
+
+    /// Conversion to tuple of references, to allow usage with std::tie().
+    constexpr operator std::tuple<T&, bool&>() noexcept { return {value, carry}; }
+};
+
+
+/// Linear arithmetic operators.
+/// @{
+
+/// Addition with carry.
+inline constexpr result_with_carry<uint64_t> addc(
+    uint64_t x, uint64_t y, bool carry = false) noexcept
+{
+#if __has_builtin(__builtin_addcll)
+    if (!is_constant_evaluated())
+    {
+        unsigned long long carryout = 0;  // NOLINT(google-runtime-int)
+        const auto s = __builtin_addcll(x, y, carry, &carryout);
+        static_assert(sizeof(s) == sizeof(uint64_t));
+        return {s, static_cast<bool>(carryout)};
+    }
+#elif __has_builtin(__builtin_ia32_addcarryx_u64)
+    if (!is_constant_evaluated())
+    {
+        unsigned long long s = 0;  // NOLINT(google-runtime-int)
+        static_assert(sizeof(s) == sizeof(uint64_t));
+        const auto carryout = __builtin_ia32_addcarryx_u64(carry, x, y, &s);
+        return {s, static_cast<bool>(carryout)};
+    }
+#endif
+
+    const auto s = x + y;
+    const auto carry1 = s < x;
+    const auto t = s + carry;
+    const auto carry2 = t < s;
+    return {t, carry1 || carry2};
+}
+
+/// Subtraction with carry (borrow).
+inline constexpr result_with_carry<uint64_t> subc(
+    uint64_t x, uint64_t y, bool carry = false) noexcept
+{
+#if __has_builtin(__builtin_subcll)
+    if (!is_constant_evaluated())
+    {
+        unsigned long long carryout = 0;  // NOLINT(google-runtime-int)
+        const auto d = __builtin_subcll(x, y, carry, &carryout);
+        static_assert(sizeof(d) == sizeof(uint64_t));
+        return {d, static_cast<bool>(carryout)};
+    }
+#elif __has_builtin(__builtin_ia32_sbb_u64)
+    if (!is_constant_evaluated())
+    {
+        unsigned long long d = 0;  // NOLINT(google-runtime-int)
+        static_assert(sizeof(d) == sizeof(uint64_t));
+        const auto carryout = __builtin_ia32_sbb_u64(carry, x, y, &d);
+        return {d, static_cast<bool>(carryout)};
+    }
+#endif
+
+    const auto d = x - y;
+    const auto carry1 = x < y;
+    const auto e = d - carry;
+    const auto carry2 = d < uint64_t{carry};
+    return {e, carry1 || carry2};
+}
+
+/// Addition with carry.
+template <unsigned N>
+inline constexpr result_with_carry<uint<N>> addc(
+    const uint<N>& x, const uint<N>& y, bool carry = false) noexcept
+{
+    uint<N> s;
+    bool k = carry;
+    for (size_t i = 0; i < uint<N>::num_words; ++i)
+    {
+        auto t = addc(x[i], y[i], k);
+        s[i] = t.value;
+        k = t.carry;
+    }
+    return {s, k};
+}
+
+inline constexpr uint128 operator+(uint128 x, uint128 y) noexcept
+{
+    return addc(x, y).value;
+}
+
+inline constexpr uint128 operator+(uint128 x) noexcept
+{
+    return x;
+}
+
+/// Performs subtraction of two unsigned numbers and returns the difference
+/// and the carry bit (aka borrow, overflow).
+template <unsigned N>
+inline constexpr result_with_carry<uint<N>> subc(
+    const uint<N>& x, const uint<N>& y, bool carry = false) noexcept
+{
+    uint<N> z;
+    bool k = carry;
+    for (size_t i = 0; i < uint<N>::num_words; ++i)
+    {
+        auto t = subc(x[i], y[i], k);
+        z[i] = t.value;
+        k = t.carry;
+    }
+    return {z, k};
+}
+
+inline constexpr uint128 operator-(uint128 x, uint128 y) noexcept
+{
+    return subc(x, y).value;
+}
+
+inline constexpr uint128 operator-(uint128 x) noexcept
+{
+    // Implementing as subtraction is better than ~x + 1.
+    // Clang9: Perfect.
+    // GCC8: Does something weird.
+    return 0 - x;
+}
+
+inline uint128& operator++(uint128& x) noexcept
+{
+    return x = x + 1;
+}
+
+inline uint128& operator--(uint128& x) noexcept
+{
+    return x = x - 1;
+}
+
+inline const uint128 operator++(uint128& x, int) noexcept  // NOLINT(readability-const-return-type)
+{
+    const auto ret = x;
+    ++x;
+    return ret;
+}
+
+inline const uint128 operator--(uint128& x, int) noexcept  // NOLINT(readability-const-return-type)
+{
+    const auto ret = x;
+    --x;
+    return ret;
+}
+
+/// Optimized addition.
+///
+/// This keeps the multiprecision addition until CodeGen so the pattern is not
+/// broken during other optimizations.
+inline constexpr uint128 fast_add(uint128 x, uint128 y) noexcept
+{
+#if INTX_HAS_BUILTIN_INT128
+    return builtin_uint128{x} + builtin_uint128{y};
+#else
+    return x + y;  // Fallback to generic addition.
+#endif
+}
+
+/// @}
+
+
+/// Comparison operators.
+///
+/// In all implementations bitwise operators are used instead of logical ones
+/// to avoid branching.
+///
+/// @{
+
+inline constexpr bool operator==(uint128 x, uint128 y) noexcept
+{
+    return ((x[0] ^ y[0]) | (x[1] ^ y[1])) == 0;
+}
+
+inline constexpr bool operator!=(uint128 x, uint128 y) noexcept
+{
+    return !(x == y);
+}
+
+inline constexpr bool operator<(uint128 x, uint128 y) noexcept
+{
+    // OPT: This should be implemented by checking the borrow of x - y,
+    //      but compilers (GCC8, Clang7)
+    //      have problem with properly optimizing subtraction.
+#if INTX_HAS_BUILTIN_INT128
+    return builtin_uint128{x} < builtin_uint128{y};
+#else
+    return (unsigned{x[1] < y[1]} | (unsigned{x[1] == y[1]} & unsigned{x[0] < y[0]})) != 0;
+#endif
+}
+
+inline constexpr bool operator<=(uint128 x, uint128 y) noexcept
+{
+    return !(y < x);
+}
+
+inline constexpr bool operator>(uint128 x, uint128 y) noexcept
+{
+    return y < x;
+}
+
+inline constexpr bool operator>=(uint128 x, uint128 y) noexcept
+{
+    return !(x < y);
+}
+
+/// @}
+
+
+/// Bitwise operators.
+/// @{
+
+inline constexpr uint128 operator~(uint128 x) noexcept
+{
+    return {~x[0], ~x[1]};
+}
+
+inline constexpr uint128 operator|(uint128 x, uint128 y) noexcept
+{
+    // Clang: perfect.
+    // GCC 8-12: stupidly uses a vector instruction in all bitwise operators.
+    return {x[0] | y[0], x[1] | y[1]};
+}
+
+inline constexpr uint128 operator&(uint128 x, uint128 y) noexcept
+{
+    return {x[0] & y[0], x[1] & y[1]};
+}
+
+inline constexpr uint128 operator^(uint128 x, uint128 y) noexcept
+{
+    return {x[0] ^ y[0], x[1] ^ y[1]};
+}
+
+inline constexpr uint128 operator<<(uint128 x, uint64_t shift) noexcept
+{
+    return (shift < 64) ?
+               // Find the part moved from lo to hi.
+               // For shift == 0 right shift by (64 - shift) is invalid so
+               // split it into 2 shifts by 1 and (63 - shift).
+               uint128{x[0] << shift, (x[1] << shift) | ((x[0] >> 1) >> (63 - shift))} :
+
+               // Guarantee "defined" behavior for shifts larger than 128.
+               (shift < 128) ? uint128{0, x[0] << (shift - 64)} : 0;
+}
+
+inline constexpr uint128 operator<<(uint128 x, uint128 shift) noexcept
+{
+    if (INTX_UNLIKELY(shift[1] != 0))
+        return 0;
+
+    return x << shift[0];
+}
+
+inline constexpr uint128 operator>>(uint128 x, uint64_t shift) noexcept
+{
+    return (shift < 64) ?
+               // Find the part moved from lo to hi.
+               // For shift == 0 left shift by (64 - shift) is invalid so
+               // split it into 2 shifts by 1 and (63 - shift).
+               uint128{(x[0] >> shift) | ((x[1] << 1) << (63 - shift)), x[1] >> shift} :
+
+               // Guarantee "defined" behavior for shifts larger than 128.
+               (shift < 128) ? uint128{x[1] >> (shift - 64)} : 0;
+}
+
+inline constexpr uint128 operator>>(uint128 x, uint128 shift) noexcept
+{
+    if (INTX_UNLIKELY(shift[1] != 0))
+        return 0;
+
+    return x >> static_cast<uint64_t>(shift);
+}
+
+/// @}
+
+
+/// Multiplication
+/// @{
+
+/// Full unsigned multiplication 64 x 64 -> 128.
+inline constexpr uint128 umul(uint64_t x, uint64_t y) noexcept
+{
+#if INTX_HAS_BUILTIN_INT128
+    return builtin_uint128{x} * builtin_uint128{y};
+#elif defined(_MSC_VER) && _MSC_VER >= 1925 && defined(_M_X64)
+    if (!is_constant_evaluated())
+    {
+        unsigned __int64 hi = 0;
+        const auto lo = _umul128(x, y, &hi);
+        return {lo, hi};
+    }
+    // For constexpr fallback to portable variant.
+#endif
+
+    // Portable full unsigned multiplication 64 x 64 -> 128.
+    uint64_t xl = x & 0xffffffff;
+    uint64_t xh = x >> 32;
+    uint64_t yl = y & 0xffffffff;
+    uint64_t yh = y >> 32;
+
+    uint64_t t0 = xl * yl;
+    uint64_t t1 = xh * yl;
+    uint64_t t2 = xl * yh;
+    uint64_t t3 = xh * yh;
+
+    uint64_t u1 = t1 + (t0 >> 32);
+    uint64_t u2 = t2 + (u1 & 0xffffffff);
+
+    uint64_t lo = (u2 << 32) | (t0 & 0xffffffff);
+    uint64_t hi = t3 + (u2 >> 32) + (u1 >> 32);
+    return {lo, hi};
+}
+
+inline constexpr uint128 operator*(uint128 x, uint128 y) noexcept
+{
+    auto p = umul(x[0], y[0]);
+    p[1] += (x[0] * y[1]) + (x[1] * y[0]);
+    return {p[0], p[1]};
+}
+
+/// @}
+
+
+/// Assignment operators.
+/// @{
+
+inline constexpr uint128& operator+=(uint128& x, uint128 y) noexcept
+{
+    return x = x + y;
+}
+
+inline constexpr uint128& operator-=(uint128& x, uint128 y) noexcept
+{
+    return x = x - y;
+}
+
+inline uint128& operator*=(uint128& x, uint128 y) noexcept
+{
+    return x = x * y;
+}
+
+inline constexpr uint128& operator|=(uint128& x, uint128 y) noexcept
+{
+    return x = x | y;
+}
+
+inline constexpr uint128& operator&=(uint128& x, uint128 y) noexcept
+{
+    return x = x & y;
+}
+
+inline constexpr uint128& operator^=(uint128& x, uint128 y) noexcept
+{
+    return x = x ^ y;
+}
+
+inline constexpr uint128& operator<<=(uint128& x, uint64_t shift) noexcept
+{
+    return x = x << shift;
+}
+
+inline constexpr uint128& operator>>=(uint128& x, uint64_t shift) noexcept
+{
+    return x = x >> shift;
+}
+
+/// @}
+
+
+inline constexpr unsigned clz_generic(uint32_t x) noexcept
+{
+    unsigned n = 32;
+    for (int i = 4; i >= 0; --i)
+    {
+        const auto s = unsigned{1} << i;
+        const auto hi = x >> s;
+        if (hi != 0)
+        {
+            n -= s;
+            x = hi;
+        }
+    }
+    return n - x;
+}
+
+inline constexpr unsigned clz_generic(uint64_t x) noexcept
+{
+    unsigned n = 64;
+    for (int i = 5; i >= 0; --i)
+    {
+        const auto s = unsigned{1} << i;
+        const auto hi = x >> s;
+        if (hi != 0)
+        {
+            n -= s;
+            x = hi;
+        }
+    }
+    return n - static_cast<unsigned>(x);
+}
+
+inline constexpr unsigned clz(uint32_t x) noexcept
+{
+#ifdef _MSC_VER
+    return clz_generic(x);
+#else
+    return x != 0 ? unsigned(__builtin_clz(x)) : 32;
+#endif
+}
+
+inline constexpr unsigned clz(uint64_t x) noexcept
+{
+#ifdef _MSC_VER
+    return clz_generic(x);
+#else
+    return x != 0 ? unsigned(__builtin_clzll(x)) : 64;
+#endif
+}
+
+inline constexpr unsigned clz(uint128 x) noexcept
+{
+    // In this order `h == 0` we get less instructions than in case of `h != 0`.
+    return x[1] == 0 ? clz(x[0]) + 64 : clz(x[1]);
+}
+
+template <typename T>
+T bswap(T x) noexcept = delete;  // Disable type auto promotion
+
+inline constexpr uint8_t bswap(uint8_t x) noexcept
+{
+    return x;
+}
+
+inline constexpr uint16_t bswap(uint16_t x) noexcept
+{
+#if __has_builtin(__builtin_bswap16)
+    return __builtin_bswap16(x);
+#else
+    #ifdef _MSC_VER
+    if (!is_constant_evaluated())
+        return _byteswap_ushort(x);
+    #endif
+    return static_cast<uint16_t>((x << 8) | (x >> 8));
+#endif
+}
+
+inline constexpr uint32_t bswap(uint32_t x) noexcept
+{
+#if __has_builtin(__builtin_bswap32)
+    return __builtin_bswap32(x);
+#else
+    #ifdef _MSC_VER
+    if (!is_constant_evaluated())
+        return _byteswap_ulong(x);
+    #endif
+    const auto a = ((x << 8) & 0xFF00FF00) | ((x >> 8) & 0x00FF00FF);
+    return (a << 16) | (a >> 16);
+#endif
+}
+
+inline constexpr uint64_t bswap(uint64_t x) noexcept
+{
+#if __has_builtin(__builtin_bswap64)
+    return __builtin_bswap64(x);
+#else
+    #ifdef _MSC_VER
+    if (!is_constant_evaluated())
+        return _byteswap_uint64(x);
+    #endif
+    const auto a = ((x << 8) & 0xFF00FF00FF00FF00) | ((x >> 8) & 0x00FF00FF00FF00FF);
+    const auto b = ((a << 16) & 0xFFFF0000FFFF0000) | ((a >> 16) & 0x0000FFFF0000FFFF);
+    return (b << 32) | (b >> 32);
+#endif
+}
+
+inline constexpr uint128 bswap(uint128 x) noexcept
+{
+    return {bswap(x[1]), bswap(x[0])};
+}
+
+
+/// Division.
+/// @{
+
+template <typename QuotT, typename RemT = QuotT>
+struct div_result
+{
+    QuotT quot;
+    RemT rem;
+
+    /// Conversion to tuple of references, to allow usage with std::tie().
+    constexpr operator std::tuple<QuotT&, RemT&>() noexcept { return {quot, rem}; }
+};
+
+namespace internal
+{
+inline constexpr uint16_t reciprocal_table_item(uint8_t d9) noexcept
+{
+    return uint16_t(0x7fd00 / (0x100 | d9));
+}
+
+#define REPEAT4(x)                                                  \
+    reciprocal_table_item((x) + 0), reciprocal_table_item((x) + 1), \
+        reciprocal_table_item((x) + 2), reciprocal_table_item((x) + 3)
+
+#define REPEAT32(x)                                                                         \
+    REPEAT4((x) + 4 * 0), REPEAT4((x) + 4 * 1), REPEAT4((x) + 4 * 2), REPEAT4((x) + 4 * 3), \
+        REPEAT4((x) + 4 * 4), REPEAT4((x) + 4 * 5), REPEAT4((x) + 4 * 6), REPEAT4((x) + 4 * 7)
+
+#define REPEAT256()                                                                           \
+    REPEAT32(32 * 0), REPEAT32(32 * 1), REPEAT32(32 * 2), REPEAT32(32 * 3), REPEAT32(32 * 4), \
+        REPEAT32(32 * 5), REPEAT32(32 * 6), REPEAT32(32 * 7)
+
+/// Reciprocal lookup table.
+constexpr uint16_t reciprocal_table[] = {REPEAT256()};
+
+#undef REPEAT4
+#undef REPEAT32
+#undef REPEAT256
+}  // namespace internal
+
+/// Computes the reciprocal (2^128 - 1) / d - 2^64 for normalized d.
+///
+/// Based on Algorithm 2 from "Improved division by invariant integers".
+inline uint64_t reciprocal_2by1(uint64_t d) noexcept
+{
+    INTX_REQUIRE(d & 0x8000000000000000);  // Must be normalized.
+
+    const uint64_t d9 = d >> 55;
+    const uint32_t v0 = internal::reciprocal_table[d9 - 256];
+
+    const uint64_t d40 = (d >> 24) + 1;
+    const uint64_t v1 = (v0 << 11) - uint32_t(uint32_t{v0 * v0} * d40 >> 40) - 1;
+
+    const uint64_t v2 = (v1 << 13) + (v1 * (0x1000000000000000 - v1 * d40) >> 47);
+
+    const uint64_t d0 = d & 1;
+    const uint64_t d63 = (d >> 1) + d0;  // ceil(d/2)
+    const uint64_t e = ((v2 >> 1) & (0 - d0)) - v2 * d63;
+    const uint64_t v3 = (umul(v2, e)[1] >> 1) + (v2 << 31);
+
+    const uint64_t v4 = v3 - (umul(v3, d) + d)[1] - d;
+    return v4;
+}
+
+inline uint64_t reciprocal_3by2(uint128 d) noexcept
+{
+    auto v = reciprocal_2by1(d[1]);
+    auto p = d[1] * v;
+    p += d[0];
+    if (p < d[0])
+    {
+        --v;
+        if (p >= d[1])
+        {
+            --v;
+            p -= d[1];
+        }
+        p -= d[1];
+    }
+
+    const auto t = umul(v, d[0]);
+
+    p += t[1];
+    if (p < t[1])
+    {
+        --v;
+        if (p >= d[1])
+        {
+            if (p > d[1] || t[0] >= d[0])
+                --v;
+        }
+    }
+    return v;
+}
+
+inline div_result<uint64_t> udivrem_2by1(uint128 u, uint64_t d, uint64_t v) noexcept
+{
+    auto q = umul(v, u[1]);
+    q = fast_add(q, u);
+
+    ++q[1];
+
+    auto r = u[0] - q[1] * d;
+
+    if (r > q[0])
+    {
+        --q[1];
+        r += d;
+    }
+
+    if (r >= d)
+    {
+        ++q[1];
+        r -= d;
+    }
+
+    return {q[1], r};
+}
+
+inline div_result<uint64_t, uint128> udivrem_3by2(
+    uint64_t u2, uint64_t u1, uint64_t u0, uint128 d, uint64_t v) noexcept
+{
+    auto q = umul(v, u2);
+    q = fast_add(q, {u1, u2});
+
+    auto r1 = u1 - q[1] * d[1];
+
+    auto t = umul(d[0], q[1]);
+
+    auto r = uint128{u0, r1} - t - d;
+    r1 = r[1];
+
+    ++q[1];
+
+    if (r1 >= q[0])
+    {
+        --q[1];
+        r += d;
+    }
+
+    if (r >= d)
+    {
+        ++q[1];
+        r -= d;
+    }
+
+    return {q[1], r};
+}
+
+inline div_result<uint128> udivrem(uint128 x, uint128 y) noexcept
+{
+    if (y[1] == 0)
+    {
+        INTX_REQUIRE(y[0] != 0);  // Division by 0.
+
+        const auto lsh = clz(y[0]);
+        const auto rsh = (64 - lsh) % 64;
+        const auto rsh_mask = uint64_t{lsh == 0} - 1;
+
+        const auto yn = y[0] << lsh;
+        const auto xn_lo = x[0] << lsh;
+        const auto xn_hi = (x[1] << lsh) | ((x[0] >> rsh) & rsh_mask);
+        const auto xn_ex = (x[1] >> rsh) & rsh_mask;
+
+        const auto v = reciprocal_2by1(yn);
+        const auto res1 = udivrem_2by1({xn_hi, xn_ex}, yn, v);
+        const auto res2 = udivrem_2by1({xn_lo, res1.rem}, yn, v);
+        return {{res2.quot, res1.quot}, res2.rem >> lsh};
+    }
+
+    if (y[1] > x[1])
+        return {0, x};
+
+    const auto lsh = clz(y[1]);
+    if (lsh == 0)
+    {
+        const auto q = unsigned{y[1] < x[1]} | unsigned{y[0] <= x[0]};
+        return {q, x - (q ? y : 0)};
+    }
+
+    const auto rsh = 64 - lsh;
+
+    const auto yn_lo = y[0] << lsh;
+    const auto yn_hi = (y[1] << lsh) | (y[0] >> rsh);
+    const auto xn_lo = x[0] << lsh;
+    const auto xn_hi = (x[1] << lsh) | (x[0] >> rsh);
+    const auto xn_ex = x[1] >> rsh;
+
+    const auto v = reciprocal_3by2({yn_lo, yn_hi});
+    const auto res = udivrem_3by2(xn_ex, xn_hi, xn_lo, {yn_lo, yn_hi}, v);
+
+    return {res.quot, res.rem >> lsh};
+}
+
+inline div_result<uint128> sdivrem(uint128 x, uint128 y) noexcept
+{
+    constexpr auto sign_mask = uint128{1} << 127;
+    const auto x_is_neg = (x & sign_mask) != 0;
+    const auto y_is_neg = (y & sign_mask) != 0;
+
+    const auto x_abs = x_is_neg ? -x : x;
+    const auto y_abs = y_is_neg ? -y : y;
+
+    const auto q_is_neg = x_is_neg ^ y_is_neg;
+
+    const auto res = udivrem(x_abs, y_abs);
+
+    return {q_is_neg ? -res.quot : res.quot, x_is_neg ? -res.rem : res.rem};
+}
+
+inline uint128 operator/(uint128 x, uint128 y) noexcept
+{
+    return udivrem(x, y).quot;
+}
+
+inline uint128 operator%(uint128 x, uint128 y) noexcept
+{
+    return udivrem(x, y).rem;
+}
+
+inline uint128& operator/=(uint128& x, uint128 y) noexcept
+{
+    return x = x / y;
+}
+
+inline uint128& operator%=(uint128& x, uint128 y) noexcept
+{
+    return x = x % y;
+}
+
+/// @}
+
+}  // namespace intx
+
+
+namespace std
+{
+template <unsigned N>
+struct numeric_limits<intx::uint<N>>  // NOLINT(cert-dcl58-cpp)
+{
+    using type = intx::uint<N>;
+
+    static constexpr bool is_specialized = true;
+    static constexpr bool is_integer = true;
+    static constexpr bool is_signed = false;
+    static constexpr bool is_exact = true;
+    static constexpr bool has_infinity = false;
+    static constexpr bool has_quiet_NaN = false;
+    static constexpr bool has_signaling_NaN = false;
+    static constexpr float_denorm_style has_denorm = denorm_absent;
+    static constexpr bool has_denorm_loss = false;
+    static constexpr float_round_style round_style = round_toward_zero;
+    static constexpr bool is_iec559 = false;
+    static constexpr bool is_bounded = true;
+    static constexpr bool is_modulo = true;
+    static constexpr int digits = CHAR_BIT * sizeof(type);
+    static constexpr int digits10 = int(0.3010299956639812 * digits);
+    static constexpr int max_digits10 = 0;
+    static constexpr int radix = 2;
+    static constexpr int min_exponent = 0;
+    static constexpr int min_exponent10 = 0;
+    static constexpr int max_exponent = 0;
+    static constexpr int max_exponent10 = 0;
+    static constexpr bool traps = std::numeric_limits<unsigned>::traps;
+    static constexpr bool tinyness_before = false;
+
+    static constexpr type min() noexcept { return 0; }
+    static constexpr type lowest() noexcept { return min(); }
+    static constexpr type max() noexcept { return ~type{0}; }
+    static constexpr type epsilon() noexcept { return 0; }
+    static constexpr type round_error() noexcept { return 0; }
+    static constexpr type infinity() noexcept { return 0; }
+    static constexpr type quiet_NaN() noexcept { return 0; }
+    static constexpr type signaling_NaN() noexcept { return 0; }
+    static constexpr type denorm_min() noexcept { return 0; }
+};
+}  // namespace std
+
+namespace intx
+{
+template <typename T>
+[[noreturn]] inline void throw_(const char* what)
+{
+#if __cpp_exceptions
+    throw T{what};
+#else
+    std::fputs(what, stderr);
+    std::abort();
+#endif
+}
+
+inline constexpr int from_dec_digit(char c)
+{
+    if (c < '0' || c > '9')
+        throw_<std::invalid_argument>("invalid digit");
+    return c - '0';
+}
+
+inline constexpr int from_hex_digit(char c)
+{
+    if (c >= 'a' && c <= 'f')
+        return c - ('a' - 10);
+    if (c >= 'A' && c <= 'F')
+        return c - ('A' - 10);
+    return from_dec_digit(c);
+}
+
+template <typename Int>
+inline constexpr Int from_string(const char* str)
+{
+    auto s = str;
+    auto x = Int{};
+    int num_digits = 0;
+
+    if (s[0] == '0' && s[1] == 'x')
+    {
+        s += 2;
+        while (const auto c = *s++)
+        {
+            if (++num_digits > int{sizeof(x) * 2})
+                throw_<std::out_of_range>(str);
+            x = (x << uint64_t{4}) | from_hex_digit(c);
+        }
+        return x;
+    }
+
+    while (const auto c = *s++)
+    {
+        if (num_digits++ > std::numeric_limits<Int>::digits10)
+            throw_<std::out_of_range>(str);
+
+        const auto d = from_dec_digit(c);
+        x = x * Int{10} + d;
+        if (x < d)
+            throw_<std::out_of_range>(str);
+    }
+    return x;
+}
+
+template <typename Int>
+inline constexpr Int from_string(const std::string& s)
+{
+    return from_string<Int>(s.c_str());
+}
+
+inline constexpr uint128 operator""_u128(const char* s)
+{
+    return from_string<uint128>(s);
+}
+
+template <unsigned N>
+inline std::string to_string(uint<N> x, int base = 10)
+{
+    if (base < 2 || base > 36)
+        throw_<std::invalid_argument>("invalid base");
+
+    if (x == 0)
+        return "0";
+
+    auto s = std::string{};
+    while (x != 0)
+    {
+        // TODO: Use constexpr udivrem_1?
+        const auto res = udivrem(x, uint<N>{base});
+        const auto d = int(res.rem);
+        const auto c = d < 10 ? '0' + d : 'a' + d - 10;
+        s.push_back(char(c));
+        x = res.quot;
+    }
+    std::reverse(s.begin(), s.end());
+    return s;
+}
+
+template <unsigned N>
+inline std::string hex(uint<N> x)
+{
+    return to_string(x, 16);
+}
+
+template <unsigned N>
+struct uint
+{
+    using word_type = uint64_t;
+    static constexpr auto word_num_bits = sizeof(word_type) * 8;
+    static constexpr auto num_bits = N;
+    static constexpr auto num_words = num_bits / word_num_bits;
+
+    static_assert(N >= 2 * word_num_bits, "Number of bits must be at lest 128");
+    static_assert(N % word_num_bits == 0, "Number of bits must be a multiply of 64");
+
+private:
+    uint64_t words_[num_words]{};
+
+public:
+    constexpr uint() noexcept = default;
+
+    /// Implicit converting constructor for any smaller uint type.
+    template <unsigned M, typename = typename std::enable_if_t<(M < N)>>
+    constexpr uint(const uint<M>& x) noexcept
+    {
+        for (size_t i = 0; i < uint<M>::num_words; ++i)
+            words_[i] = x[i];
+    }
+
+    template <typename... T,
+        typename = std::enable_if_t<std::conjunction_v<std::is_convertible<T, uint64_t>...>>>
+    constexpr uint(T... v) noexcept : words_{static_cast<uint64_t>(v)...}
+    {}
+
+    constexpr uint64_t& operator[](size_t i) noexcept { return words_[i]; }
+
+    constexpr const uint64_t& operator[](size_t i) const noexcept { return words_[i]; }
+
+    constexpr explicit operator bool() const noexcept { return *this != uint{}; }
+
+    template <unsigned M, typename = typename std::enable_if_t<(M < N)>>
+    explicit operator uint<M>() const noexcept
+    {
+        uint<M> r;
+        for (size_t i = 0; i < uint<M>::num_words; ++i)
+            r[i] = words_[i];
+        return r;
+    }
+
+    /// Explicit converting operator for all builtin integral types.
+    template <typename Int, typename = typename std::enable_if_t<std::is_integral_v<Int>>>
+    explicit operator Int() const noexcept
+    {
+        static_assert(sizeof(Int) <= sizeof(uint64_t));
+        return static_cast<Int>(words_[0]);
+    }
+
+    friend inline constexpr uint operator+(const uint& x, const uint& y) noexcept
+    {
+        return addc(x, y).value;
+    }
+
+    inline constexpr uint& operator+=(const uint& y) noexcept { return *this = *this + y; }
+
+    inline constexpr uint operator-() const noexcept { return ~*this + uint{1}; }
+
+    friend inline constexpr uint operator-(const uint& x, const uint& y) noexcept
+    {
+        return subc(x, y).value;
+    }
+
+    inline constexpr uint& operator-=(const uint& y) noexcept { return *this = *this - y; }
+
+    /// Multiplication implementation using word access
+    /// and discarding the high part of the result product.
+    friend inline constexpr uint operator*(const uint& x, const uint& y) noexcept
+    {
+        uint<N> p;
+        for (size_t j = 0; j < num_words; j++)
+        {
+            uint64_t k = 0;
+            for (size_t i = 0; i < (num_words - j - 1); i++)
+            {
+                auto a = addc(p[i + j], k);
+                auto t = umul(x[i], y[j]) + uint128{a.value, a.carry};
+                p[i + j] = t[0];
+                k = t[1];
+            }
+            p[num_words - 1] += x[num_words - j - 1] * y[j] + k;
+        }
+        return p;
+    }
+
+    inline constexpr uint& operator*=(const uint& y) noexcept { return *this = *this * y; }
+
+    friend inline constexpr uint operator/(const uint& x, const uint& y) noexcept
+    {
+        return udivrem(x, y).quot;
+    }
+
+    friend inline constexpr uint operator%(const uint& x, const uint& y) noexcept
+    {
+        return udivrem(x, y).rem;
+    }
+
+    inline constexpr uint& operator/=(const uint& y) noexcept { return *this = *this / y; }
+
+    inline constexpr uint& operator%=(const uint& y) noexcept { return *this = *this % y; }
+
+
+    inline constexpr uint operator~() const noexcept
+    {
+        uint z;
+        for (size_t i = 0; i < num_words; ++i)
+            z[i] = ~words_[i];
+        return z;
+    }
+
+    friend inline constexpr uint operator|(const uint& x, const uint& y) noexcept
+    {
+        uint z;
+        for (size_t i = 0; i < num_words; ++i)
+            z[i] = x[i] | y[i];
+        return z;
+    }
+
+    inline constexpr uint& operator|=(const uint& y) noexcept { return *this = *this | y; }
+
+    friend inline constexpr uint operator&(const uint& x, const uint& y) noexcept
+    {
+        uint z;
+        for (size_t i = 0; i < num_words; ++i)
+            z[i] = x[i] & y[i];
+        return z;
+    }
+
+    inline constexpr uint& operator&=(const uint& y) noexcept { return *this = *this & y; }
+
+    friend inline constexpr uint operator^(const uint& x, const uint& y) noexcept
+    {
+        uint z;
+        for (size_t i = 0; i < num_words; ++i)
+            z[i] = x[i] ^ y[i];
+        return z;
+    }
+
+    inline constexpr uint& operator^=(const uint& y) noexcept { return *this = *this ^ y; }
+};
+
+using uint192 = uint<192>;
+using uint256 = uint<256>;
+using uint320 = uint<320>;
+using uint384 = uint<384>;
+using uint512 = uint<512>;
+
+template <unsigned N>
+inline constexpr bool operator==(const uint<N>& x, const uint<N>& y) noexcept
+{
+    uint64_t folded = 0;
+    for (size_t i = 0; i < uint<N>::num_words; ++i)
+        folded |= (x[i] ^ y[i]);
+    return folded == 0;
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr bool operator==(const uint<N>& x, const T& y) noexcept
+{
+    return x == uint<N>(y);
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr bool operator==(const T& x, const uint<N>& y) noexcept
+{
+    return uint<N>(y) == x;
+}
+
+
+template <unsigned N>
+inline constexpr bool operator!=(const uint<N>& x, const uint<N>& y) noexcept
+{
+    return !(x == y);
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr bool operator!=(const uint<N>& x, const T& y) noexcept
+{
+    return x != uint<N>(y);
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr bool operator!=(const T& x, const uint<N>& y) noexcept
+{
+    return uint<N>(x) != y;
+}
+
+#if !defined(_MSC_VER) || _MSC_VER < 1916  // This kills MSVC 2017 compiler.
+inline constexpr bool operator<(const uint256& x, const uint256& y) noexcept
+{
+    auto xp = uint128{x[2], x[3]};
+    auto yp = uint128{y[2], y[3]};
+    if (xp == yp)
+    {
+        xp = uint128{x[0], x[1]};
+        yp = uint128{y[0], y[1]};
+    }
+    return xp < yp;
+}
+#endif
+
+template <unsigned N>
+inline constexpr bool operator<(const uint<N>& x, const uint<N>& y) noexcept
+{
+    return subc(x, y).carry;
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr bool operator<(const uint<N>& x, const T& y) noexcept
+{
+    return x < uint<N>(y);
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr bool operator<(const T& x, const uint<N>& y) noexcept
+{
+    return uint<N>(x) < y;
+}
+
+
+template <unsigned N>
+inline constexpr bool operator>(const uint<N>& x, const uint<N>& y) noexcept
+{
+    return y < x;
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr bool operator>(const uint<N>& x, const T& y) noexcept
+{
+    return x > uint<N>(y);
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr bool operator>(const T& x, const uint<N>& y) noexcept
+{
+    return uint<N>(x) > y;
+}
+
+
+template <unsigned N>
+inline constexpr bool operator>=(const uint<N>& x, const uint<N>& y) noexcept
+{
+    return !(x < y);
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr bool operator>=(const uint<N>& x, const T& y) noexcept
+{
+    return x >= uint<N>(y);
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr bool operator>=(const T& x, const uint<N>& y) noexcept
+{
+    return uint<N>(x) >= y;
+}
+
+
+template <unsigned N>
+inline constexpr bool operator<=(const uint<N>& x, const uint<N>& y) noexcept
+{
+    return !(y < x);
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr bool operator<=(const uint<N>& x, const T& y) noexcept
+{
+    return x <= uint<N>(y);
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr bool operator<=(const T& x, const uint<N>& y) noexcept
+{
+    return uint<N>(x) <= y;
+}
+
+/// Signed less than comparison.
+///
+/// Interprets the arguments as two's complement signed integers
+/// and checks the "less than" relation.
+template <unsigned N>
+inline constexpr bool slt(const uint<N>& x, const uint<N>& y) noexcept
+{
+    constexpr auto top_word_idx = uint<N>::num_words - 1;
+    const auto x_neg = static_cast<int64_t>(x[top_word_idx]) < 0;
+    const auto y_neg = static_cast<int64_t>(y[top_word_idx]) < 0;
+    return ((x_neg ^ y_neg) != 0) ? x_neg : x < y;
+}
+
+
+inline constexpr uint256 operator<<(const uint256& x, uint64_t shift) noexcept
+{
+    if (INTX_UNLIKELY(shift >= uint256::num_bits))
+        return 0;
+
+    constexpr auto num_bits = uint256::num_bits;
+    constexpr auto half_bits = num_bits / 2;
+
+    const auto xlo = uint128{x[0], x[1]};
+
+    if (shift < half_bits)
+    {
+        const auto lo = xlo << shift;
+
+        const auto xhi = uint128{x[2], x[3]};
+
+        // Find the part moved from lo to hi.
+        // The shift right here can be invalid:
+        // for shift == 0 => rshift == half_bits.
+        // Split it into 2 valid shifts by (rshift - 1) and 1.
+        const auto rshift = half_bits - shift;
+        const auto lo_overflow = (xlo >> (rshift - 1)) >> 1;
+        const auto hi = (xhi << shift) | lo_overflow;
+        return {lo[0], lo[1], hi[0], hi[1]};
+    }
+
+    const auto hi = xlo << (shift - half_bits);
+    return {0, 0, hi[0], hi[1]};
+}
+
+template <unsigned N>
+inline constexpr uint<N> operator<<(const uint<N>& x, uint64_t shift) noexcept
+{
+    if (INTX_UNLIKELY(shift >= uint<N>::num_bits))
+        return 0;
+
+    constexpr auto word_bits = sizeof(uint64_t) * 8;
+
+    const auto s = shift % word_bits;
+    const auto skip = static_cast<size_t>(shift / word_bits);
+
+    uint<N> r;
+    uint64_t carry = 0;
+    for (size_t i = 0; i < (uint<N>::num_words - skip); ++i)
+    {
+        r[i + skip] = (x[i] << s) | carry;
+        carry = (x[i] >> (word_bits - s - 1)) >> 1;
+    }
+    return r;
+}
+
+
+inline constexpr uint256 operator>>(const uint256& x, uint64_t shift) noexcept
+{
+    if (INTX_UNLIKELY(shift >= uint256::num_bits))
+        return 0;
+
+    constexpr auto num_bits = uint256::num_bits;
+    constexpr auto half_bits = num_bits / 2;
+
+    const auto xhi = uint128{x[2], x[3]};
+
+    if (shift < half_bits)
+    {
+        const auto hi = xhi >> shift;
+
+        const auto xlo = uint128{x[0], x[1]};
+
+        // Find the part moved from hi to lo.
+        // The shift left here can be invalid:
+        // for shift == 0 => lshift == half_bits.
+        // Split it into 2 valid shifts by (lshift - 1) and 1.
+        const auto lshift = half_bits - shift;
+        const auto hi_overflow = (xhi << (lshift - 1)) << 1;
+        const auto lo = (xlo >> shift) | hi_overflow;
+        return {lo[0], lo[1], hi[0], hi[1]};
+    }
+
+    const auto lo = xhi >> (shift - half_bits);
+    return {lo[0], lo[1], 0, 0};
+}
+
+template <unsigned N>
+inline constexpr uint<N> operator>>(const uint<N>& x, uint64_t shift) noexcept
+{
+    if (INTX_UNLIKELY(shift >= uint<N>::num_bits))
+        return 0;
+
+    constexpr auto num_words = uint<N>::num_words;
+    constexpr auto word_bits = sizeof(uint64_t) * 8;
+
+    const auto s = shift % word_bits;
+    const auto skip = static_cast<size_t>(shift / word_bits);
+
+    uint<N> r;
+    uint64_t carry = 0;
+    for (size_t i = 0; i < (num_words - skip); ++i)
+    {
+        r[num_words - 1 - i - skip] = (x[num_words - 1 - i] >> s) | carry;
+        carry = (x[num_words - 1 - i] << (word_bits - s - 1)) << 1;
+    }
+    return r;
+}
+
+template <unsigned N>
+inline constexpr uint<N> operator<<(const uint<N>& x, const uint<N>& shift) noexcept
+{
+    uint64_t high_words_fold = 0;
+    for (size_t i = 1; i < uint<N>::num_words; ++i)
+        high_words_fold |= shift[i];
+
+    if (INTX_UNLIKELY(high_words_fold != 0))
+        return 0;
+
+    return x << shift[0];
+}
+
+template <unsigned N>
+inline constexpr uint<N> operator>>(const uint<N>& x, const uint<N>& shift) noexcept
+{
+    uint64_t high_words_fold = 0;
+    for (size_t i = 1; i < uint<N>::num_words; ++i)
+        high_words_fold |= shift[i];
+
+    if (INTX_UNLIKELY(high_words_fold != 0))
+        return 0;
+
+    return x >> shift[0];
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr uint<N> operator<<(const uint<N>& x, const T& shift) noexcept
+{
+    if (shift < T{sizeof(x) * 8})
+        return x << static_cast<uint64_t>(shift);
+    return 0;
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr uint<N> operator>>(const uint<N>& x, const T& shift) noexcept
+{
+    if (shift < T{sizeof(x) * 8})
+        return x >> static_cast<uint64_t>(shift);
+    return 0;
+}
+
+template <unsigned N>
+inline constexpr uint<N>& operator>>=(uint<N>& x, uint64_t shift) noexcept
+{
+    return x = x >> shift;
+}
+
+
+inline constexpr uint64_t* as_words(uint128& x) noexcept
+{
+    return &x[0];
+}
+
+inline constexpr const uint64_t* as_words(const uint128& x) noexcept
+{
+    return &x[0];
+}
+
+template <unsigned N>
+inline constexpr uint64_t* as_words(uint<N>& x) noexcept
+{
+    return &x[0];
+}
+
+template <unsigned N>
+inline constexpr const uint64_t* as_words(const uint<N>& x) noexcept
+{
+    return &x[0];
+}
+
+template <typename T>
+inline uint8_t* as_bytes(T& x) noexcept
+{
+    static_assert(std::is_trivially_copyable_v<T>);  // As in bit_cast.
+    return reinterpret_cast<uint8_t*>(&x);
+}
+
+template <typename T>
+inline const uint8_t* as_bytes(const T& x) noexcept
+{
+    static_assert(std::is_trivially_copyable_v<T>);  // As in bit_cast.
+    return reinterpret_cast<const uint8_t*>(&x);
+}
+
+template <unsigned N>
+inline constexpr uint<2 * N> umul(const uint<N>& x, const uint<N>& y) noexcept
+{
+    constexpr auto num_words = uint<N>::num_words;
+
+    uint<2 * N> p;
+    for (size_t j = 0; j < num_words; ++j)
+    {
+        uint64_t k = 0;
+        for (size_t i = 0; i < num_words; ++i)
+        {
+            auto a = addc(p[i + j], k);
+            auto t = umul(x[i], y[j]) + uint128{a.value, a.carry};
+            p[i + j] = t[0];
+            k = t[1];
+        }
+        p[j + num_words] = k;
+    }
+    return p;
+}
+
+template <unsigned N>
+inline constexpr uint<N> exp(uint<N> base, uint<N> exponent) noexcept
+{
+    auto result = uint<N>{1};
+    if (base == 2)
+        return result << exponent;
+
+    while (exponent != 0)
+    {
+        if ((exponent & 1) != 0)
+            result *= base;
+        base *= base;
+        exponent >>= 1;
+    }
+    return result;
+}
+
+template <unsigned N>
+inline constexpr unsigned count_significant_words(const uint<N>& x) noexcept
+{
+    for (size_t i = uint<N>::num_words; i > 0; --i)
+    {
+        if (x[i - 1] != 0)
+            return static_cast<unsigned>(i);
+    }
+    return 0;
+}
+
+inline constexpr unsigned count_significant_bytes(uint64_t x) noexcept
+{
+    return (64 - clz(x) + 7) / 8;
+}
+
+template <unsigned N>
+inline constexpr unsigned count_significant_bytes(const uint<N>& x) noexcept
+{
+    const auto w = count_significant_words(x);
+    return (w != 0) ? count_significant_bytes(x[w - 1]) + (w - 1) * 8 : 0;
+}
+
+template <unsigned N>
+inline constexpr unsigned clz(const uint<N>& x) noexcept
+{
+    constexpr unsigned num_words = uint<N>::num_words;
+    const auto s = count_significant_words(x);
+    if (s == 0)
+        return num_words * 64;
+    return clz(x[s - 1]) + (num_words - s) * 64;
+}
+
+namespace internal
+{
+/// Counts the number of zero leading bits in nonzero argument x.
+inline constexpr unsigned clz_nonzero(uint64_t x) noexcept
+{
+    INTX_REQUIRE(x != 0);
+#ifdef _MSC_VER
+    return clz_generic(x);
+#else
+    return unsigned(__builtin_clzll(x));
+#endif
+}
+
+template <unsigned M, unsigned N>
+struct normalized_div_args  // NOLINT(cppcoreguidelines-pro-type-member-init)
+{
+    uint<N> divisor;
+    uint<M + 64> numerator;
+    int num_divisor_words;
+    int num_numerator_words;
+    unsigned shift;
+};
+
+template <unsigned M, unsigned N>
+[[gnu::always_inline]] inline normalized_div_args<M, N> normalize(
+    const uint<M>& numerator, const uint<N>& denominator) noexcept
+{
+    static constexpr auto num_numerator_words = uint<M>::num_words;
+    static constexpr auto num_denominator_words = uint<N>::num_words;
+
+    auto* u = as_words(numerator);
+    auto* v = as_words(denominator);
+
+    normalized_div_args<M, N> na;
+    auto* un = as_words(na.numerator);
+    auto* vn = as_words(na.divisor);
+
+    auto& m = na.num_numerator_words;
+    for (m = num_numerator_words; m > 0 && u[m - 1] == 0; --m)
+        ;
+
+    auto& n = na.num_divisor_words;
+    for (n = num_denominator_words; n > 0 && v[n - 1] == 0; --n)
+        ;
+
+    na.shift = clz_nonzero(v[n - 1]);  // Use clz_nonzero() to avoid clang analyzer's warning.
+    if (na.shift)
+    {
+        for (int i = num_denominator_words - 1; i > 0; --i)
+            vn[i] = (v[i] << na.shift) | (v[i - 1] >> (64 - na.shift));
+        vn[0] = v[0] << na.shift;
+
+        un[num_numerator_words] = u[num_numerator_words - 1] >> (64 - na.shift);
+        for (int i = num_numerator_words - 1; i > 0; --i)
+            un[i] = (u[i] << na.shift) | (u[i - 1] >> (64 - na.shift));
+        un[0] = u[0] << na.shift;
+    }
+    else
+    {
+        na.numerator = numerator;
+        na.divisor = denominator;
+    }
+
+    // Skip the highest word of numerator if not significant.
+    if (un[m] != 0 || un[m - 1] >= vn[n - 1])
+        ++m;
+
+    return na;
+}
+
+/// Divides arbitrary long unsigned integer by 64-bit unsigned integer (1 word).
+/// @param u    The array of a normalized numerator words. It will contain
+///             the quotient after execution.
+/// @param len  The number of numerator words.
+/// @param d    The normalized divisor.
+/// @return     The remainder.
+inline uint64_t udivrem_by1(uint64_t u[], int len, uint64_t d) noexcept
+{
+    INTX_REQUIRE(len >= 2);
+
+    const auto reciprocal = reciprocal_2by1(d);
+
+    auto rem = u[len - 1];  // Set the top word as remainder.
+    u[len - 1] = 0;         // Reset the word being a part of the result quotient.
+
+    auto it = &u[len - 2];
+    do
+    {
+        std::tie(*it, rem) = udivrem_2by1({*it, rem}, d, reciprocal);
+    } while (it-- != &u[0]);
+
+    return rem;
+}
+
+/// Divides arbitrary long unsigned integer by 128-bit unsigned integer (2 words).
+/// @param u    The array of a normalized numerator words. It will contain the
+///             quotient after execution.
+/// @param len  The number of numerator words.
+/// @param d    The normalized divisor.
+/// @return     The remainder.
+inline uint128 udivrem_by2(uint64_t u[], int len, uint128 d) noexcept
+{
+    INTX_REQUIRE(len >= 3);
+
+    const auto reciprocal = reciprocal_3by2(d);
+
+    auto rem = uint128{u[len - 2], u[len - 1]};  // Set the 2 top words as remainder.
+    u[len - 1] = u[len - 2] = 0;  // Reset these words being a part of the result quotient.
+
+    auto it = &u[len - 3];
+    do
+    {
+        std::tie(*it, rem) = udivrem_3by2(rem[1], rem[0], *it, d, reciprocal);
+    } while (it-- != &u[0]);
+
+    return rem;
+}
+
+/// s = x + y.
+inline bool add(uint64_t s[], const uint64_t x[], const uint64_t y[], int len) noexcept
+{
+    // OPT: Add MinLen template parameter and unroll first loop iterations.
+    INTX_REQUIRE(len >= 2);
+
+    bool carry = false;
+    for (int i = 0; i < len; ++i)
+        std::tie(s[i], carry) = addc(x[i], y[i], carry);
+    return carry;
+}
+
+/// r = x - multiplier * y.
+inline uint64_t submul(
+    uint64_t r[], const uint64_t x[], const uint64_t y[], int len, uint64_t multiplier) noexcept
+{
+    // OPT: Add MinLen template parameter and unroll first loop iterations.
+    INTX_REQUIRE(len >= 1);
+
+    uint64_t borrow = 0;
+    for (int i = 0; i < len; ++i)
+    {
+        const auto s = x[i] - borrow;
+        const auto p = umul(y[i], multiplier);
+        borrow = p[1] + (x[i] < s);
+        r[i] = s - p[0];
+        borrow += (s < r[i]);
+    }
+    return borrow;
+}
+
+inline void udivrem_knuth(
+    uint64_t q[], uint64_t u[], int ulen, const uint64_t d[], int dlen) noexcept
+{
+    INTX_REQUIRE(dlen >= 3);
+    INTX_REQUIRE(ulen >= dlen);
+
+    const auto divisor = uint128{d[dlen - 2], d[dlen - 1]};
+    const auto reciprocal = reciprocal_3by2(divisor);
+    for (int j = ulen - dlen - 1; j >= 0; --j)
+    {
+        const auto u2 = u[j + dlen];
+        const auto u1 = u[j + dlen - 1];
+        const auto u0 = u[j + dlen - 2];
+
+        uint64_t qhat{};
+        if (INTX_UNLIKELY((uint128{u1, u2}) == divisor))  // Division overflows.
+        {
+            qhat = ~uint64_t{0};
+
+            u[j + dlen] = u2 - submul(&u[j], &u[j], d, dlen, qhat);
+        }
+        else
+        {
+            uint128 rhat;
+            std::tie(qhat, rhat) = udivrem_3by2(u2, u1, u0, divisor, reciprocal);
+
+            bool carry{};
+            const auto overflow = submul(&u[j], &u[j], d, dlen - 2, qhat);
+            std::tie(u[j + dlen - 2], carry) = subc(rhat[0], overflow);
+            std::tie(u[j + dlen - 1], carry) = subc(rhat[1], carry);
+
+            if (INTX_UNLIKELY(carry))
+            {
+                --qhat;
+                u[j + dlen - 1] += divisor[1] + add(&u[j], &u[j], d, dlen - 1);
+            }
+        }
+
+        q[j] = qhat;  // Store quotient digit.
+    }
+}
+
+}  // namespace internal
+
+template <unsigned M, unsigned N>
+constexpr div_result<uint<M>, uint<N>> udivrem(const uint<M>& u, const uint<N>& v) noexcept
+{
+    auto na = internal::normalize(u, v);
+
+    if (na.num_numerator_words <= na.num_divisor_words)
+        return {0, static_cast<uint<N>>(u)};
+
+    if (na.num_divisor_words == 1)
+    {
+        const auto r = internal::udivrem_by1(
+            as_words(na.numerator), na.num_numerator_words, as_words(na.divisor)[0]);
+        return {static_cast<uint<M>>(na.numerator), r >> na.shift};
+    }
+
+    if (na.num_divisor_words == 2)
+    {
+        const auto d = as_words(na.divisor);
+        const auto r =
+            internal::udivrem_by2(as_words(na.numerator), na.num_numerator_words, {d[0], d[1]});
+        return {static_cast<uint<M>>(na.numerator), r >> na.shift};
+    }
+
+    auto un = as_words(na.numerator);  // Will be modified.
+
+    uint<M> q;
+    internal::udivrem_knuth(
+        as_words(q), &un[0], na.num_numerator_words, as_words(na.divisor), na.num_divisor_words);
+
+    uint<N> r;
+    auto rw = as_words(r);
+    for (int i = 0; i < na.num_divisor_words - 1; ++i)
+        rw[i] = na.shift ? (un[i] >> na.shift) | (un[i + 1] << (64 - na.shift)) : un[i];
+    rw[na.num_divisor_words - 1] = un[na.num_divisor_words - 1] >> na.shift;
+
+    return {q, r};
+}
+
+template <unsigned N>
+inline constexpr div_result<uint<N>> sdivrem(const uint<N>& u, const uint<N>& v) noexcept
+{
+    const auto sign_mask = uint<N>{1} << (sizeof(u) * 8 - 1);
+    auto u_is_neg = (u & sign_mask) != 0;
+    auto v_is_neg = (v & sign_mask) != 0;
+
+    auto u_abs = u_is_neg ? -u : u;
+    auto v_abs = v_is_neg ? -v : v;
+
+    auto q_is_neg = u_is_neg ^ v_is_neg;
+
+    auto res = udivrem(u_abs, v_abs);
+
+    return {q_is_neg ? -res.quot : res.quot, u_is_neg ? -res.rem : res.rem};
+}
+
+inline constexpr uint256 bswap(const uint256& x) noexcept
+{
+    return {bswap(x[3]), bswap(x[2]), bswap(x[1]), bswap(x[0])};
+}
+
+template <unsigned N>
+inline constexpr uint<N> bswap(const uint<N>& x) noexcept
+{
+    constexpr auto num_words = uint<N>::num_words;
+    uint<N> z;
+    for (size_t i = 0; i < num_words; ++i)
+        z[num_words - 1 - i] = bswap(x[i]);
+    return z;
+}
+
+
+// Support for type conversions for binary operators.
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr uint<N>& operator<<=(uint<N>& x, const T& y) noexcept
+{
+    return x = x << y;
+}
+
+template <unsigned N, typename T,
+    typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
+inline constexpr uint<N>& operator>>=(uint<N>& x, const T& y) noexcept
+{
+    return x = x >> y;
+}
+
+
+inline uint256 addmod(const uint256& x, const uint256& y, const uint256& mod) noexcept
+{
+    // Fast path for mod >= 2^192, with x and y at most slightly bigger than mod.
+    // This is always the case when x and y are already reduced modulo mod.
+    // Based on https://github.com/holiman/uint256/pull/86.
+    if ((mod[3] != 0) && (x[3] <= mod[3]) && (y[3] <= mod[3]))
+    {
+        // Normalize x in case it is bigger than mod.
+        auto xn = x;
+        auto xd = subc(x, mod);
+        if (!xd.carry)
+            xn = xd.value;
+
+        // Normalize y in case it is bigger than mod.
+        auto yn = y;
+        auto yd = subc(y, mod);
+        if (!yd.carry)
+            yn = yd.value;
+
+        auto a = addc(xn, yn);
+        auto av = a.value;
+        auto b = subc(av, mod);
+        auto bv = b.value;
+        if (a.carry || !b.carry)
+            return bv;
+        return av;
+    }
+
+    auto s = addc(x, y);
+    uint<256 + 64> n = s.value;
+    n[4] = s.carry;
+    return udivrem(n, mod).rem;
+}
+
+inline uint256 mulmod(const uint256& x, const uint256& y, const uint256& mod) noexcept
+{
+    return udivrem(umul(x, y), mod).rem;
+}
+
+
+inline constexpr uint256 operator"" _u256(const char* s)
+{
+    return from_string<uint256>(s);
+}
+
+inline constexpr uint512 operator"" _u512(const char* s)
+{
+    return from_string<uint512>(s);
+}
+
+
+/// Convert native representation to/from little-endian byte order.
+/// intx and built-in integral types are supported.
+template <typename T>
+inline constexpr T to_little_endian(const T& x) noexcept
+{
+    if constexpr (byte_order_is_little_endian)
+        return x;
+    else if constexpr (std::is_integral_v<T>)
+        return bswap(x);
+    else  // Wordwise bswap.
+    {
+        T r;
+        for (size_t i = 0; i < T::num_words; ++i)
+            r[i] = bswap(x[i]);
+        return r;
+    }
+}
+
+/// Convert native representation to/from big-endian byte order.
+/// intx and built-in integral types are supported.
+template <typename T>
+inline constexpr T to_big_endian(const T& x) noexcept
+{
+    if constexpr (byte_order_is_little_endian)
+        return bswap(x);
+    else if constexpr (std::is_integral_v<T>)
+        return x;
+    else  // Swap words.
+    {
+        T r;
+        for (size_t i = 0; i < T::num_words; ++i)
+            r[T::num_words - 1 - i] = x[i];
+        return r;
+    }
+}
+
+namespace le  // Conversions to/from LE bytes.
+{
+template <typename T, unsigned M>
+inline T load(const uint8_t (&src)[M]) noexcept
+{
+    static_assert(
+        M == sizeof(T), "the size of source bytes must match the size of the destination uint");
+    T x;
+    std::memcpy(&x, src, sizeof(x));
+    return to_little_endian(x);
+}
+
+template <typename T>
+inline void store(uint8_t (&dst)[sizeof(T)], const T& x) noexcept
+{
+    const auto d = to_little_endian(x);
+    std::memcpy(dst, &d, sizeof(d));
+}
+
+namespace unsafe
+{
+template <typename T>
+inline T load(const uint8_t* src) noexcept
+{
+    T x;
+    std::memcpy(&x, src, sizeof(x));
+    return to_little_endian(x);
+}
+
+template <typename T>
+inline void store(uint8_t* dst, const T& x) noexcept
+{
+    const auto d = to_little_endian(x);
+    std::memcpy(dst, &d, sizeof(d));
+}
+}  // namespace unsafe
+}  // namespace le
+
+
+namespace be  // Conversions to/from BE bytes.
+{
+/// Loads an integer value from bytes of big-endian order.
+/// If the size of bytes is smaller than the result, the value is zero-extended.
+template <typename T, unsigned M>
+inline T load(const uint8_t (&src)[M]) noexcept
+{
+    static_assert(M <= sizeof(T),
+        "the size of source bytes must not exceed the size of the destination uint");
+    T x{};
+    std::memcpy(&as_bytes(x)[sizeof(T) - M], src, M);
+    x = to_big_endian(x);
+    return x;
+}
+
+template <typename IntT, typename T>
+inline IntT load(const T& t) noexcept
+{
+    return load<IntT>(t.bytes);
+}
+
+/// Stores an integer value in a bytes array in big-endian order.
+template <typename T>
+inline void store(uint8_t (&dst)[sizeof(T)], const T& x) noexcept
+{
+    const auto d = to_big_endian(x);
+    std::memcpy(dst, &d, sizeof(d));
+}
+
+/// Stores an SrcT value in .bytes field of type DstT. The .bytes must be an array of uint8_t
+/// of the size matching the size of uint.
+template <typename DstT, typename SrcT>
+inline DstT store(const SrcT& x) noexcept
+{
+    DstT r{};
+    store(r.bytes, x);
+    return r;
+}
+
+/// Stores the truncated value of an uint in a bytes array.
+/// Only the least significant bytes from big-endian representation of the uint
+/// are stored in the result bytes array up to array's size.
+template <unsigned M, unsigned N>
+inline void trunc(uint8_t (&dst)[M], const uint<N>& x) noexcept
+{
+    static_assert(M < N / 8, "destination must be smaller than the source value");
+    const auto d = to_big_endian(x);
+    std::memcpy(dst, &as_bytes(d)[sizeof(d) - M], M);
+}
+
+/// Stores the truncated value of an uint in the .bytes field of an object of type T.
+template <typename T, unsigned N>
+inline T trunc(const uint<N>& x) noexcept
+{
+    T r{};
+    trunc(r.bytes, x);
+    return r;
+}
+
+namespace unsafe
+{
+/// Loads an uint value from a buffer. The user must make sure
+/// that the provided buffer is big enough. Therefore marked "unsafe".
+template <typename IntT>
+inline IntT load(const uint8_t* src) noexcept
+{
+    // Align bytes.
+    // TODO: Using memcpy() directly triggers this optimization bug in GCC:
+    //   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107837
+    alignas(IntT) std::byte aligned_storage[sizeof(IntT)];
+    std::memcpy(&aligned_storage, src, sizeof(IntT));
+    // TODO(C++23): Use std::start_lifetime_as<uint256>().
+    return to_big_endian(*reinterpret_cast<const IntT*>(&aligned_storage));
+}
+
+/// Stores an integer value at the provided pointer in big-endian order. The user must make sure
+/// that the provided buffer is big enough to fit the value. Therefore marked "unsafe".
+template <typename T>
+inline void store(uint8_t* dst, const T& x) noexcept
+{
+    const auto d = to_big_endian(x);
+    std::memcpy(dst, &d, sizeof(d));
+}
+
+/// Specialization for uint256.
+inline void store(uint8_t* dst, const uint256& x) noexcept
+{
+    // Store byte-swapped words in primitive temporaries. This helps with memory aliasing
+    // and GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107837
+    // TODO: Use std::byte instead of uint8_t.
+    const auto v0 = to_big_endian(x[0]);
+    const auto v1 = to_big_endian(x[1]);
+    const auto v2 = to_big_endian(x[2]);
+    const auto v3 = to_big_endian(x[3]);
+
+    // Store words in reverse (big-endian) order, write addresses are ascending.
+    std::memcpy(dst, &v3, sizeof(v3));
+    std::memcpy(dst + 8, &v2, sizeof(v2));
+    std::memcpy(dst + 16, &v1, sizeof(v1));
+    std::memcpy(dst + 24, &v0, sizeof(v0));
+}
+
+}  // namespace unsafe
+
+}  // namespace be
+
+}  // namespace intx
+
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif

--- a/external/eosio.evm/silkworm.hpp
+++ b/external/eosio.evm/silkworm.hpp
@@ -1,0 +1,313 @@
+/*
+   Copyright 2020-2021 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// #include "util.hpp"
+
+#include <cassert>
+// #include <regex>
+
+// #include <silkworm/common/as_range.hpp>
+
+namespace silkworm {
+
+typedef std::vector<uint8_t> bytes;
+
+// ASCII -> hex value (0xff means bad [hex] char)
+static constexpr uint8_t kUnhexTable[256] = {
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+// ASCII -> hex value << 4 (upper nibble) (0xff means bad [hex] char)
+static constexpr uint8_t kUnhexTable4[256] = {
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80,
+    0x90, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+// ByteView left_pad(ByteView view, size_t min_size, Bytes& buffer) {
+//     if (view.size() >= min_size) {
+//         return view;
+//     }
+
+//     if (buffer.size() < min_size) {
+//         buffer.resize(min_size);
+//     } else {
+//         // view & buffer might overlap in memory,
+//         // so we avoid shrinking the buffer prior to the memmove
+//     }
+
+//     assert(view.size() < min_size);
+//     size_t prefix_len{min_size - view.size()};
+
+//     // view & buffer might overlap in memory,
+//     // thus memmove instead of memcpy
+//     std::memmove(buffer.data() + prefix_len, view.data(), view.size());
+
+//     buffer.resize(min_size);
+//     std::memset(buffer.data(), 0, prefix_len);
+
+//     return buffer;
+// }
+
+// ByteView right_pad(ByteView view, size_t min_size, Bytes& buffer) {
+//     if (view.size() >= min_size) {
+//         return view;
+//     }
+
+//     if (buffer.size() < view.size()) {
+//         buffer.resize(view.size());
+//     } else {
+//         // view & buffer might overlap in memory,
+//         // so we avoid shrinking the buffer prior to the memmove
+//     }
+
+//     // view & buffer might overlap in memory,
+//     // thus memmove instead of memcpy
+//     std::memmove(buffer.data(), view.data(), view.size());
+
+//     assert(view.size() < min_size);
+//     buffer.resize(view.size());
+//     buffer.resize(min_size);
+
+//     return buffer;
+// }
+
+// evmc::address to_evmc_address(ByteView bytes) {
+//     evmc::address out;
+//     if (!bytes.empty()) {
+//         size_t n{std::min(bytes.length(), kAddressLength)};
+//         std::memcpy(out.bytes + kAddressLength - n, bytes.data(), n);
+//     }
+//     return out;
+// }
+
+// evmc::bytes32 to_bytes32(ByteView bytes) {
+//     evmc::bytes32 out;
+//     if (!bytes.empty()) {
+//         size_t n{std::min(bytes.length(), kHashLength)};
+//         std::memcpy(out.bytes + kHashLength - n, bytes.data(), n);
+//     }
+//     return out;
+// }
+
+// ByteView zeroless_view(ByteView data) {
+//     return data.substr(static_cast<size_t>(
+//         std::distance(data.begin(), as_range::find_if_not(data, [](const auto& b) { return b == 0x0; }))));
+// }
+
+std::string to_hex(bytes bytes, bool with_prefix) {
+    static const char* kHexDigits{"0123456789abcdef"};
+    std::string out(bytes.size() * 2 + (with_prefix ? 2 : 0), '\0');
+    char* dest{&out[0]};
+    if (with_prefix) {
+        *dest++ = '0';
+        *dest++ = 'x';
+    }
+    for (const auto& b : bytes) {
+        *dest++ = kHexDigits[b >> 4];    // Hi
+        *dest++ = kHexDigits[b & 0x0f];  // Lo
+    }
+    return out;
+}
+
+// std::string abridge(std::string_view input, size_t length) {
+//     if (input.length() <= length) {
+//         return std::string(input);
+//     }
+//     return std::string(input.substr(0, length)) + "...";
+// }
+
+static inline uint8_t unhex_lut(uint8_t x) { return kUnhexTable[x]; }
+static inline uint8_t unhex_lut4(uint8_t x) { return kUnhexTable4[x]; }
+
+// std::optional<unsigned> decode_hex_digit(char ch) noexcept {
+//     auto ret{unhex_lut(static_cast<uint8_t>(ch))};
+//     if (ret == 0xff) {
+//         return std::nullopt;
+//     }
+//     return ret;
+// }
+
+std::optional<bytes> from_hex(std::string_view hex) noexcept {
+    if (hex.length() >= 2 && hex[0] == '0' && (hex[1] == 'x' || hex[1] == 'X')) {
+        hex.remove_prefix(2);
+    }
+    if (hex.empty()) {
+        return bytes{};
+    }
+
+    size_t pos(hex.length() & 1);  // "[0x]1" is legit and has to be treated as "[0x]01"
+    bytes out((hex.length() + pos) / 2, '\0');
+    const char* src{const_cast<char*>(hex.data())};
+    const char* last = src + hex.length();
+    uint8_t* dst{&out[0]};
+
+    if (pos) {
+        auto b{unhex_lut(static_cast<uint8_t>(*src++))};
+        if (b == 0xff) {
+            return std::nullopt;
+        }
+        *dst++ = b;
+    }
+
+    // following "while" is unrolling the loop when we have >= 4 target bytes
+    // this is optional, but 5-10% faster
+    while (last - src >= 8) {
+        auto a{unhex_lut4(static_cast<uint8_t>(*src++))};
+        auto b{unhex_lut(static_cast<uint8_t>(*src++))};
+        auto c{unhex_lut4(static_cast<uint8_t>(*src++))};
+        auto d{unhex_lut(static_cast<uint8_t>(*src++))};
+        auto e{unhex_lut4(static_cast<uint8_t>(*src++))};
+        auto f{unhex_lut(static_cast<uint8_t>(*src++))};
+        auto g{unhex_lut4(static_cast<uint8_t>(*src++))};
+        auto h{unhex_lut(static_cast<uint8_t>(*src++))};
+        if ((b | d | f | h) == 0xff || (a | c | e | g) == 0xff) {
+            return std::nullopt;
+        }
+        *dst++ = a | b;
+        *dst++ = c | d;
+        *dst++ = e | f;
+        *dst++ = g | h;
+    }
+
+    while (src < last) {
+        auto a{unhex_lut4(static_cast<uint8_t>(*src++))};
+        auto b{unhex_lut(static_cast<uint8_t>(*src++))};
+        if (a == 0xff || b == 0xff) {
+            return std::nullopt;
+        }
+        *dst++ = a | b;
+    }
+    return out;
+}
+
+// inline bool case_insensitive_char_comparer(char a, char b) { return (tolower(a) == tolower(b)); }
+
+// bool iequals(const std::string& a, const std::string& b) {
+//     return (a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin(), case_insensitive_char_comparer));
+// }
+
+// std::optional<uint64_t> parse_size(const std::string& sizestr) {
+//     if (sizestr.empty()) {
+//         return 0ull;
+//     }
+
+//     static const std::regex pattern{R"(^(\d*)(\.\d{1,3})?\ *?(B|KB|MB|GB|TB)?$)", std::regex_constants::icase};
+//     std::smatch matches;
+//     if (!std::regex_search(sizestr, matches, pattern, std::regex_constants::match_default)) {
+//         return std::nullopt;
+//     }
+
+//     std::string int_part, dec_part, suf_part;
+//     uint64_t multiplier{1};  // Default for bytes (B|b)
+
+//     int_part = matches[1].str();
+//     if (!matches[2].str().empty()) {
+//         dec_part = matches[2].str().substr(1);
+//     }
+//     suf_part = matches[3].str();
+
+//     if (!suf_part.empty()) {
+//         if (iequals(suf_part, "KB")) {
+//             multiplier = kKibi;
+//         } else if (iequals(suf_part, "MB")) {
+//             multiplier = kMebi;
+//         } else if (iequals(suf_part, "GB")) {
+//             multiplier = kGibi;
+//         } else if (iequals(suf_part, "TB")) {
+//             multiplier = kTebi;
+//         }
+//     }
+
+//     auto number{std::strtoull(int_part.c_str(), nullptr, 10)};
+//     number *= multiplier;
+//     if (!dec_part.empty()) {
+//         // Use literals, so we don't deal with floats and doubles
+//         auto base{"1" + std::string(dec_part.size(), '0')};
+//         auto b{std::strtoul(base.c_str(), nullptr, 10)};
+//         auto d{std::strtoul(dec_part.c_str(), nullptr, 10)};
+//         number += multiplier * d / b;
+//     }
+//     return number;
+// }
+
+// std::string human_size(uint64_t bytes) {
+//     static const char* suffix[]{"B", "KB", "MB", "GB", "TB"};
+//     static const uint32_t items{sizeof(suffix) / sizeof(suffix[0])};
+//     uint32_t index{0};
+//     double value{static_cast<double>(bytes)};
+//     while (value >= kKibi) {
+//         value /= kKibi;
+//         if (++index == (items - 1)) {
+//             break;
+//         }
+//     }
+//     static char output[64];
+//     sprintf(output, "%.02lf %s", value, suffix[index]);
+//     return output;
+// }
+
+// size_t prefix_length(ByteView a, ByteView b) {
+//     size_t len{std::min(a.length(), b.length())};
+//     for (size_t i{0}; i < len; ++i) {
+//         if (a[i] != b[i]) {
+//             return i;
+//         }
+//     }
+//     return len;
+// }
+
+// std::vector<std::string> split(std::string_view source, std::string_view delimiter) {
+//     std::vector<std::string> res{};
+//     if (delimiter.length() >= source.length() || !delimiter.length()) {
+//         res.emplace_back(source);
+//         return res;
+//     }
+//     size_t pos{0};
+//     while ((pos = source.find(delimiter)) != std::string::npos) {
+//         res.emplace_back(source.substr(0, pos));
+//         source.remove_prefix(pos + delimiter.length());
+//     }
+//     // Any residual part of input where delimiter is not found
+//     if (source.length()) {
+//         res.emplace_back(source);
+//     }
+//     return res;
+// }
+
+}  // namespace silkworm

--- a/external/eosio.evm/silkworm.hpp
+++ b/external/eosio.evm/silkworm.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 /*
    Copyright 2020-2021 The Silkworm Authors
 


### PR DESCRIPTION
# EVM support features
- [x] Oracle TVL `update` supports EVM contracts
- [x] `setcontracts` ACTION now includes `evm_contracts`
- [x] Oracle supports adding EVM token addresses to contributes to TVL calculations
- [x] Add EVM callback support with `balanceOf(address)` method selector to fetch EVM token balance using EOS smart contract.
- [x] Automatic `balanceof` updates prior to calling `update` or `updateall`
- [x] Claim rewards to EVM address (using EVM bridge)
- [x] Set maximum EVM & Native contracts to a limit of 10 (due to CPU limitations to compute TVL by oracle)

## EVM Token Support
- [x] Multichain Tether (USDT)
- [x] Wrapped EOS (WEOS)
- [x] Multichain Circle (USDC)

# Solves issues
- https://github.com/eosnetworkfoundation/eosio.yield-contracts/issues/12
- https://github.com/eosnetworkfoundation/eosio.yield-contracts/issues/13
- https://github.com/eosnetworkfoundation/eosio.yield-contracts/issues/33

# New ACTIONS
- [x] `addevmtoken`
- [x] `delevmtoken`

# New TABLES
- [x] `evm.tokens`
- [x] `evm.balances`

# 🔑 Authority changes
- [x] `setcontracts` no longer require `has_auth` on every contract
> adding EVM contracts do not require authentication, so manual review process is always required for contract changes.
> A lot of friction with protocol admins that cannot add contracts because of strict MSIG permissions or nulled permissions.
- [x] `claim` added permission to Admin account (when protocol no longer have access, can perform final claim & unregister protocol)
- [x] `update` action can only be triggered internally by `oracle.yield`
> EVM callback `balanceof` needs to be triggered prior to `update` action being called, which `updateall` takes care of the inline action ordering.

# Minor logic changes
- [x] remove `setevm` ACTION, logic has been merged into `setcontracts`
- [x] `setcontracts` only supports EOS or EOS EVM contracts (not both)
- [x] validate USDT contract to be `tethertether`
- [x] USD/USDC/USDT token do not require oracles ID's (pegged at $1.00 USD)
- [x] `setrate` has optional values (in case no change for other values, makes it easier to review MSIG's)

## ACTION `addevmtoken`

- **authority**: `get_self()`

> Add {{sym}} token using {{address}} EOS EVM address.

### params

- `{bytes} address` - token EOS EVM address
- `{uint8_t} decimals` - token decimals
- `{symbol_code} symcode` - token symbol code

### example

```bash
$ cleos push action oracle.yield addevmtoken '["fa9343c3897324496a05fc75abed6bac29f8a40f", 6, "USDT"]' -p oracle.yield
$ cleos push action oracle.yield addevmtoken '["c00592aA41D32D137dC480d9f6d0Df19b860104F", 18, "EOS"]' -p oracle.yield
```

## ACTION `delevmtoken`

- **authority**: `get_self()`

> Delete {{address}} EOS EVM token as supported asset

### params

- `{bytes} address` - EOS EVM token address

### example

```bash
$ cleos push action oracle.yield deltoken '["fa9343c3897324496a05fc75abed6bac29f8a40f"]' -p oracle.yield
```

## TABLE `evm.tokens`

### params

- `{uint64_t} token_id` - (primary key) EOS EVM token account ID
- `{bytes} address` - EOS EVM token address
- `{uint8_t} decimals` - EOS EVM token decimals
- `{symbol} sym` - token symbol

### example

```json
[
    {
        "token_id": 2,
        "address": "c00592aA41D32D137dC480d9f6d0Df19b860104F",
        "decimals": "18",
        "sym": "4,EOS"
    }
    {
        "token_id": 201,
        "sym": "4,USDT",
        "address": "fa9343c3897324496a05fc75abed6bac29f8a40f",
        "decimals": "6"
    },
]
```

## TABLE `evm.balances`

**Scope**: `<uint64_t> token_id`

### params

- `{uint64_t} address_id` - (primary key) EOS EVM address account ID
- `{bytes} address` - EOS EVM address
- `{asset} balance` - current token balance

### example

```json
{
    "address_id": 663,
    "address": "671A5e209A5496256ee21386EC3EaB9054d658A2",
    "balance": "173151.7110 USDT"
}
```
